### PR TITLE
fix: Remove redundant tattooAngle parameter

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -751,7 +751,6 @@
                 }
                 formData.append('mask', maskToSend);
                 formData.append('prompt', '');
-                formData.append('tattooAngle', STATE.tattooAngle); // NEW: Send the rotation angle
 
                 const response = await fetch(`${CONFIG.API_URL}/generate-final-tattoo`, {
                     method: 'POST',


### PR DESCRIPTION
This commit removes the `tattooAngle` parameter from the form data sent to the backend. This parameter was a remnant of a previous implementation and was likely overriding the rotation information baked into the generated mask.

By removing this parameter, the backend will be forced to rely solely on the provided mask for all transformation data (position, scale, and rotation), which should resolve the issue of the final image not reflecting your chosen angle.