### PR TITLE
fix: Separate rotation from mask for backend processing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -751,7 +751,8 @@
                 }
                 formData.append('mask', maskToSend);
                 formData.append('prompt', '');
-                formData.append('tattooAngle', 0); // Send a default angle of 0
+                const rotationSlider = document.getElementById('rotationSlider');
+                formData.append('tattooAngle', rotationSlider.value);
 
                 const response = await fetch(`${CONFIG.API_URL}/generate-final-tattoo`, {
                     method: 'POST',

--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -191,9 +191,9 @@ const drawing = {
             const maskTattoo = drawing.tattooMesh.clone();
             maskTattoo.material = new THREE.MeshBasicMaterial({ color: 0xffffff });
 
-            // 4. Manually copy transformations to the clone
+            // 4. Manually copy transformations to the clone (but not rotation)
             maskTattoo.position.copy(drawing.tattooMesh.position);
-            maskTattoo.rotation.copy(drawing.tattooMesh.rotation);
+            maskTattoo.rotation.set(0, 0, 0);
             maskTattoo.scale.copy(drawing.tattooMesh.scale);
 
             maskScene.add(maskTattoo);


### PR DESCRIPTION
This commit fixes the final bug in the tattoo placement feature where the rotation was not being correctly applied by the backend.

The new approach is based on the understanding that the backend expects to perform the rotation itself.

Changes:
1.  `drawing.js`: The `updateMask` function is modified to generate a mask that contains the correct position and scale, but is NOT rotated.
2.  `index.html`: The form data now sends the actual rotation value from the slider in the `tattooAngle` parameter.

This change ensures that the backend receives the transformation data in the format it expects, which should result in the final image correctly reflecting all your adjustments.