### PR TITLE
fix: Render transformed texture to mask

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -751,10 +751,7 @@
                 }
                 formData.append('mask', maskToSend);
                 formData.append('prompt', '');
-                const rotationSlider = document.getElementById('rotationSlider');
-                const angle = rotationSlider.value;
-                console.log(`DEBUG: Appending tattooAngle to form data: ${angle}`);
-                formData.append('tattooAngle', angle);
+                console.log("DEBUG: All transformation data is now baked into the mask.");
 
                 const response = await fetch(`${CONFIG.API_URL}/generate-final-tattoo`, {
                     method: 'POST',


### PR DESCRIPTION
This commit fixes the persistent bug where tattoo rotation was not being applied correctly by the backend.

The new approach ensures that the mask sent to the backend is a complete, transformed rendering of the tattoo.

Changes:
- `drawing.js`: The `updateMask` function now renders the tattoo mesh with its full texture and transformations (position, scale, and rotation) onto a black background.
- `index.html`: The separate `tattooAngle` parameter has been removed, as all transformation data is now correctly baked into the mask image itself.

This should be the definitive fix for the tattoo placement feature.