### PR TITLE
fix: Bake scale into mask and send angle separately

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -756,11 +756,6 @@
                 console.log(`DEBUG: Inverting angle. Appending tattooAngle to form data: ${angle}`);
                 formData.append('tattooAngle', angle);
 
-                const sizeSlider = document.getElementById('sizeSlider');
-                const scale = parseFloat(sizeSlider.value) / 100;
-                console.log(`DEBUG: Appending tattooScale to form data: ${scale}`);
-                formData.append('tattooScale', scale);
-
                 const response = await fetch(`${CONFIG.API_URL}/generate-final-tattoo`, {
                     method: 'POST',
                     headers: {

--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -185,10 +185,10 @@ const drawing = {
             // Clone the tattoo mesh, but use its original material (with the texture)
             const maskTattoo = drawing.tattooMesh.clone();
 
-            // Manually copy transformations to the clone, but not scale or rotation
+            // Manually copy transformations to the clone (position and scale, but not rotation)
             maskTattoo.position.copy(drawing.tattooMesh.position);
             maskTattoo.rotation.set(0, 0, 0);
-            maskTattoo.scale.set(1, 1, 1);
+            maskTattoo.scale.copy(drawing.tattooMesh.scale);
 
             maskScene.add(maskTattoo);
 


### PR DESCRIPTION
This commit fixes the issue with the tattoo size not being correctly applied in the final image.

The new implementation is based on the understanding that the backend expects to handle rotation via a parameter, but expects scale to be baked into the mask itself.

Changes:
- `drawing.js`: The `updateMask` function now generates a mask that is correctly scaled and positioned, but not rotated.
- `index.html`: The `tattooScale` parameter has been removed from the form data, as it was not being used by the backend. The `tattooAngle` parameter is still sent.

This should be the final fix to get all transformations working correctly.