### PR TITLE
This commit includes two fixes for issues related to frontend image h…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -737,7 +737,17 @@
             try {
                 const formData = new FormData();
                 formData.append('skinImage', STATE.currentImage);
-                const tattooDesignBlob = await (await fetch(STATE.uploadedTattooDesignBase64)).blob();
+
+                // --- NEW: Generate and use the scaled tattoo data ---
+                const scaledTattooDataUrl = await window.drawing.getScaledTattooData();
+                if (!scaledTattooDataUrl) {
+                    utils.showError('Could not generate the scaled tattoo image. Please try again.');
+                    utils.hideLoading();
+                    return;
+                }
+                const tattooDesignBlob = await (await fetch(scaledTattooDataUrl)).blob();
+                // --- END NEW ---
+
                 // Crucial fix: Use the correct original file type, not hardcoded 'image/jpeg'
                 // Ensure the name also suggests PNG if the type is PNG
                 const tattooDesignFileName = tattooDesignBlob.type === 'image/png' ? 'tattoo_design.png' : 'tattoo_design.jpeg';

--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -228,6 +228,43 @@ const drawing = {
         });
     },
 
+    getScaledTattooData: () => {
+        return new Promise((resolve) => {
+            console.log("DEBUG: getScaledTattooData started.");
+            if (!drawing.renderer || !drawing.tattooMesh) {
+                console.error("DEBUG: Cannot generate scaled tattoo: components not initialized.");
+                return resolve(null);
+            }
+
+            const tattoo = drawing.tattooMesh;
+            const texture = tattoo.material.map;
+            if (!texture || !texture.image) {
+                console.error("DEBUG: Tattoo texture not loaded.");
+                return resolve(null);
+            }
+
+            // Get original texture dimensions
+            const originalWidth = texture.image.width;
+            const originalHeight = texture.image.height;
+
+            // Apply the mesh's scale to the dimensions
+            const scaledWidth = originalWidth * tattoo.scale.x;
+            const scaledHeight = originalHeight * tattoo.scale.y;
+
+            const tempCanvas = document.createElement('canvas');
+            tempCanvas.width = scaledWidth;
+            tempCanvas.height = scaledHeight;
+            const ctx = tempCanvas.getContext('2d');
+
+            // Draw the original image onto the canvas at the new scaled size
+            ctx.drawImage(texture.image, 0, 0, scaledWidth, scaledHeight);
+
+            const dataUrl = tempCanvas.toDataURL('image/png');
+            console.log("DEBUG: Scaled tattoo data generated.");
+            resolve(dataUrl);
+        });
+    },
+
     clearCanvas: () => {
         if (drawing.renderer) {
             drawing.renderer.setAnimationLoop(null);


### PR DESCRIPTION
…andling:

1.  **PNG Transparency:** Addresses an issue where PNG images with alpha channels were losing their transparency. The `THREE.WebGLRenderer` is now initialized with `alpha: true`, and the mask generation logic has been updated to render a transparent background. This ensures the alpha channel is preserved.

2.  **Resize Slider:** Fixes a bug where the resize slider was not affecting the final output size. A new function, `getScaledTattooData`, has been added to `drawing.js` to create a pre-scaled version of the tattoo image on the frontend. This scaled image is now sent to the backend, ensuring your desired size is respected in the final generation.