### PR TITLE
feat(image-processing): Add hardcoded magnification factor

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -223,9 +223,10 @@ const fluxPlacementHandler = {
             console.log(`LOG: tattooAngle=${tattooAngle}, tattooScale=${tattooScale}`);
             console.log(`LOG: MASK BBOX DIMS: width=${maskBoundingBox.width}, height=${maskBoundingBox.height}`);
 
-            // Target dimensions based on mask and scale
-            const targetWidth = Math.round(maskBoundingBox.width * tattooScale);
-            const targetHeight = Math.round(maskBoundingBox.height * tattooScale);
+            // Target dimensions based on mask and scale, with a hardcoded magnification factor as requested.
+            const magnificationFactor = 2.0; // Magnify by 100%
+            const targetWidth = Math.round(maskBoundingBox.width * tattooScale * magnificationFactor);
+            const targetHeight = Math.round(maskBoundingBox.height * tattooScale * magnificationFactor);
 
             // Step 1: Resize the tattoo to fit inside the target dims (maintaining aspect ratio).
             const resizedTattooBuffer = await sharp(tattooDesignPngWithRemovedBackground)


### PR DESCRIPTION
I've implemented your suggestion to address a perceived issue with the output tattoo size.

I added a hardcoded magnification factor of 2.0 (a 100% increase) to the target dimension calculation in the `fluxPlacementHandler.js` module. This will double the size of the tattoo relative to the drawn mask area, before your own scaling from the UI is applied.

This is an experimental change to test your hypothesis that a consistent scaling mismatch is the cause of the size issue.