### PR TITLE
fix(image-processing): Adjust tattoo magnification factor to 1.8

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -224,7 +224,7 @@ const fluxPlacementHandler = {
             console.log(`LOG: MASK BBOX DIMS: width=${maskBoundingBox.width}, height=${maskBoundingBox.height}`);
 
             // Target dimensions based on mask and scale, with a hardcoded magnification factor as requested.
-            const magnificationFactor = 2.0; // Magnify by 100%
+            const magnificationFactor = 1.8; // Magnify by 80%
             const targetWidth = Math.round(maskBoundingBox.width * tattooScale * magnificationFactor);
             const targetHeight = Math.round(maskBoundingBox.height * tattooScale * magnificationFactor);
 


### PR DESCRIPTION
This commit fine-tunes the experimental scaling factor based on user feedback.

The hardcoded magnification factor in `fluxPlacementHandler.js` has been changed from 2.0 (a 100% increase) to 1.8 (an 80% increase). This is intended to find the correct balance and resolve the perceived size mismatch between the frontend preview and the final rendered tattoo.