### PR TITLE
feat: UX overhaul and rebranding to Slate.Tattoo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SLATE - AI Tattoo Visualization</title>
+    <title>Slate.Tattoo - AI Tattoo Visualization</title>
     <link rel="stylesheet" href="css/styles.css">
     <!-- Import map for Three.js -->
     <script type="importmap">
@@ -23,7 +23,7 @@
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <h1>SLATE</h1>
+                <h1>Slate.Tattoo</h1>
                 <span class="tagline">AI Tattoo Platform</span> </div>
             <div class="nav-menu">
                 <span id="userInfo" class="user-info"></span>
@@ -197,7 +197,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>SLATE</h3>
+                    <h3>Slate.Tattoo</h3>
                     <p>AI-powered tattoo visualization platform</p>
                 </div>
                 <div class="footer-section">
@@ -220,7 +220,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 SLATE. Made with ❤️ by itayash@gmail.com</p>
+                <p>&copy; 2024 Slate.Tattoo. Made with ❤️ by itayash@gmail.com</p>
             </div>
         </div>
     </footer>

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -155,14 +155,14 @@ const auth = {
     setAuthMode: (isRegister) => {
         auth.isRegisterMode = isRegister;
         if (isRegister) {
-            auth.authTitle.textContent = 'Register for SLATE';
+            auth.authTitle.textContent = 'Register for Slate.Tattoo';
             auth.authSwitchText.textContent = 'Already have an account?';
             auth.authSwitchLink.textContent = 'Login';
             auth.authForm.querySelector('button[type="submit"]').textContent = 'Register';
             auth.usernameGroup.style.display = 'block';
             auth.usernameInput.setAttribute('required', 'required');
         } else {
-            auth.authTitle.textContent = 'Login to SLATE';
+            auth.authTitle.textContent = 'Login to Slate.Tattoo';
             auth.authSwitchText.textContent = "Don't have an account?";
             auth.authSwitchLink.textContent = 'Register';
             auth.authForm.querySelector('button[type="submit"]').textContent = 'Login';

--- a/frontend/welcome.html
+++ b/frontend/welcome.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SLATE - AI Tattoo Platform</title>
+    <title>Slate.Tattoo - AI Tattoo Platform</title>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -13,7 +13,7 @@
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <h1>SLATE</h1>
+                <h1>Slate.Tattoo</h1>
                 <span class="tagline">AI Tattoo Platform</span>
             </div>
             <div class="nav-menu">
@@ -27,7 +27,7 @@
         <section class="hero-section">
             <div class="container">
                 <h2>Visualize Your Ink. Perfect Your Look.</h2>
-                <p class="hero-tagline">SLATE uses AI to let you see tattoo designs on your own skin before you get inked.</p>
+                <p class="hero-tagline">Slate.Tattoo uses AI to let you see tattoo designs on your own skin before you get inked.</p>
                 <button id="heroRegisterBtn" class="btn btn-primary btn-lg">Get Started - It's Free!</button>
             </div>
         </section>
@@ -55,7 +55,7 @@
         <div id="authModal" class="modal">
             <div class="modal-content">
                 <div class="auth-container">
-                    <h2 id="authTitle">Login to SLATE</h2>
+                    <h2 id="authTitle">Login to Slate.Tattoo</h2>
                     <form id="authForm">
                         <div class="form-group">
                             <label for="email">Email</label>
@@ -85,7 +85,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>SLATE</h3>
+                    <h3>Slate.Tattoo</h3>
                     <p>AI-powered tattoo visualization platform</p>
                 </div>
                 <div class="footer-section">
@@ -108,7 +108,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 SLATE. Made with ❤️ by itayash@gmail.com</p>
+                <p>&copy; 2024 Slate.Tattoo. Made with ❤️ by itayash@gmail.com</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
I've performed a major UX overhaul and rebranded the application from "SkinTip" to "Slate.Tattoo".

Key changes:
- I rebranded the application to "Slate.Tattoo" across the entire codebase, including frontend and backend files.
- I changed your journey through the app from uploading a custom tattoo design to selecting a sketch from a new, filterable gallery.
- A new `gallery.js` file has been added to provide mock data for the gallery.
- The loading screen is now enhanced to display information about the artist of the selected sketch while the AI is processing.
- I removed obsolete code related to the old application flow.
- Based on your feedback, I updated the branding to "Slate.Tattoo" in the header, footer, and other UI elements.