### PR TITLE
fix: Use surrogate pairs for emojis in WhatsApp links

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -872,7 +872,7 @@
                     artistSketchesGrid.innerHTML += `<img src="${artistSketches[i].imageUrl}" alt="${artistSketches[i].name}">`;
                 }
 
-                const earlyContactMessage = `Hi ${STATE.selectedStencil.artist.name}, 😀.\n\nI'm interested in this tattoo design, and I'm waiting for the AI preview.\n\nHere is the original stencil:\n${STATE.selectedStencil.imageUrl}\n\nCan you tell me more about it? 😷\n\nThanks!`;
+                const earlyContactMessage = `Hi ${STATE.selectedStencil.artist.name}, \uD83D\uDE00.\n\nI'm interested in this tattoo design, and I'm waiting for the AI preview.\n\nHere is the original stencil:\n${STATE.selectedStencil.imageUrl}\n\nCan you tell me more about it? \uD83D\uDE37\n\nThanks!`;
                 artistWhatsappLink.href = `https://wa.me/${STATE.selectedStencil.artist.whatsapp}?text=${encodeURIComponent(earlyContactMessage)}`;
                 artistInfo.style.display = 'block';
             } else {
@@ -969,9 +969,9 @@
                 if (STATE.selectedStencil && STATE.selectedStencil.artist && artistContactSection) {
                     const whatsappLink = document.getElementById('whatsappLink');
                     const artistName = STATE.selectedStencil.artist.name;
-                    const introText = `Hi ${artistName}, 😀.\n\nI got this stunning AI tattoo from your catalog 🔥.\n\nHere are the previews:\n`;
+                    const introText = `Hi ${artistName}, \uD83D\uDE00.\n\nI got this stunning AI tattoo from your catalog \uD83D\uDD25.\n\nHere are the previews:\n`;
                     const imageUrlsText = STATE.generatedImages.join('\n');
-                    const outroText = `\nCan you share more details about yourself and the tattoo? 😷\n\nThanks!`;
+                    const outroText = `\nCan you share more details about yourself and the tattoo? \uD83D\uDE37\n\nThanks!`;
                     const fullMessage = introText + imageUrlsText + outroText;
 
                     whatsappLink.href = `https://wa.me/${STATE.selectedStencil.artist.whatsapp}?text=${encodeURIComponent(fullMessage)}`;


### PR DESCRIPTION
This commit resolves an issue where emojis were not rendering correctly in the pre-filled WhatsApp message, instead appearing as replacement characters (�).

The root cause was improper encoding of emoji characters for the `wa.me` URL. The fix replaces the literal emoji characters in the JavaScript message strings with their standard, universally supported surrogate pair escape sequences (e.g., `\uD83D\uDE00`).

This ensures that the emojis are correctly interpreted and encoded by `encodeURIComponent`, leading to proper display in the WhatsApp client across all platforms. This has been applied to both the early contact message (on the loading screen) and the final results message.