### PR TITLE
fix: Remove emojis from WhatsApp messages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -872,7 +872,7 @@
                     artistSketchesGrid.innerHTML += `<img src="${artistSketches[i].imageUrl}" alt="${artistSketches[i].name}">`;
                 }
 
-                const earlyContactMessage = `Hi ${STATE.selectedStencil.artist.name}, 😀.\n\nI'm interested in this tattoo design, and I'm waiting for the AI preview.\n\nHere is the original stencil:\n${STATE.selectedStencil.imageUrl}\n\nCan you tell me more about it? 😷\n\nThanks!`;
+                const earlyContactMessage = `Hi ${STATE.selectedStencil.artist.name}.\n\nI'm interested in this tattoo design, and I'm waiting for the AI preview.\n\nHere is the original stencil:\n${STATE.selectedStencil.imageUrl}\n\nCan you tell me more about it?\n\nThanks!`;
                 artistWhatsappLink.href = `https://wa.me/${STATE.selectedStencil.artist.whatsapp}?text=${encodeURIComponent(earlyContactMessage)}`;
                 artistInfo.style.display = 'block';
             } else {
@@ -969,9 +969,9 @@
                 if (STATE.selectedStencil && STATE.selectedStencil.artist && artistContactSection) {
                     const whatsappLink = document.getElementById('whatsappLink');
                     const artistName = STATE.selectedStencil.artist.name;
-                    const introText = `Hi ${artistName}, 😀.\n\nI got this stunning AI tattoo from your catalog 🔥.\n\nHere are the previews:\n`;
+                    const introText = `Hi ${artistName}.\n\nI got this stunning AI tattoo from your catalog. Here are the previews:\n`;
                     const imageUrlsText = STATE.generatedImages.join('\n');
-                    const outroText = `\nCan you share more details about yourself and the tattoo? 😷\n\nThanks!`;
+                    const outroText = `\nCan you share more details about yourself and the tattoo?\n\nThanks!`;
                     const fullMessage = introText + imageUrlsText + outroText;
 
                     whatsappLink.href = `https://wa.me/${STATE.selectedStencil.artist.whatsapp}?text=${encodeURIComponent(fullMessage)}`;


### PR DESCRIPTION
This commit removes all emoji characters and escape sequences from the WhatsApp message strings in `frontend/index.html`.

After multiple failed attempts to fix the emoji rendering issue, this change ensures the messages are clean, readable, and functional, albeit without the emojis. This resolves the issue of replacement characters (�) appearing in the chat.

This affects both the early contact message on the loading screen and the final contact message on the results screen.