### PR TITLE
feat: Implement user event tracking and PPC reporting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -496,6 +496,35 @@ app.post('/api/generate-final-tattoo',
     }
 );
 
+app.post('/api/log-event', authenticateToken, async (req, res) => {
+    const { event_type, artist_id, stencil_id } = req.body;
+    const user_id = req.user.id;
+
+    if (!event_type) {
+        return res.status(400).json({ error: 'Event type is required.' });
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from('user_events')
+            .insert({
+                user_id,
+                event_type,
+                artist_id,
+                stencil_id
+            });
+
+        if (error) {
+            console.error('Error logging event:', error);
+            throw error;
+        }
+
+        res.status(201).json({ success: true, message: 'Event logged.' });
+    } catch (error) {
+        res.status(500).json({ error: 'Failed to log event.' });
+    }
+});
+
 // Error handling middleware (catches errors from previous middleware/routes)
 app.use((error, req, res, next) => {
     if (error instanceof multer.MulterError) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -235,6 +235,27 @@
     <script type="module">
         console.log('Main inline script starting...');
 
+        async function logUserEvent(eventType, artistId, stencilId) {
+            if (!STATE.token) return; // Don't log events for anonymous users
+
+            try {
+                await fetch(`${CONFIG.API_URL}/log-event`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${STATE.token}`
+                    },
+                    body: JSON.stringify({
+                        event_type: eventType,
+                        artist_id: artistId,
+                        stencil_id: stencilId
+                    })
+                });
+            } catch (error) {
+                console.warn('Failed to log user event:', error);
+            }
+        }
+
         /**
          * Resizes an image Data URL to a maximum width/height while maintaining aspect ratio.
          * Returns a Promise that resolves with the new Data URL.
@@ -526,6 +547,7 @@
                         }
 
                         if (selectedStencil) {
+                            logUserEvent('SKETCH_CLICK', selectedStencil.artist.id, selectedStencil.id);
                             STATE.selectedStencil = selectedStencil;
 
                             // --- Show selected stencil preview ---
@@ -578,6 +600,7 @@
                 }
 
                 if (selectedStencil) {
+                    logUserEvent('SKETCH_CLICK', selectedStencil.artist.id, selectedStencil.id);
                     STATE.selectedStencil = selectedStencil;
 
                     // --- Show selected stencil preview ---
@@ -874,6 +897,7 @@
 
                 const earlyContactMessage = `Hi ${STATE.selectedStencil.artist.name}.\n\nI'm interested in this tattoo design, and I'm waiting for the AI preview.\n\nHere is the original stencil:\n${STATE.selectedStencil.imageUrl}\n\nCan you tell me more about it?\n\nThanks!`;
                 artistWhatsappLink.href = `https://wa.me/${STATE.selectedStencil.artist.whatsapp}?text=${encodeURIComponent(earlyContactMessage)}`;
+                artistWhatsappLink.onclick = () => logUserEvent('WHATSAPP_CONTACT', STATE.selectedStencil.artist.id, STATE.selectedStencil.id);
                 artistInfo.style.display = 'block';
             } else {
                 artistInfo.style.display = 'none';
@@ -975,6 +999,7 @@
                     const fullMessage = introText + imageUrlsText + outroText;
 
                     whatsappLink.href = `https://wa.me/${STATE.selectedStencil.artist.whatsapp}?text=${encodeURIComponent(fullMessage)}`;
+                    whatsappLink.onclick = () => logUserEvent('WHATSAPP_CONTACT', STATE.selectedStencil.artist.id, STATE.selectedStencil.id);
                     artistContactSection.style.display = 'block';
                 } else if (artistContactSection) {
                     artistContactSection.style.display = 'none';


### PR DESCRIPTION
This commit introduces a comprehensive analytics feature to track user interactions and provide pay-per-click (PPC) reporting data.

Key changes:
- **Database:** A new `user_events` table is created to log user actions. An SQL `VIEW` named `ppc_report` is also created to provide a simple, aggregated summary of clicks per artist for easy billing.
- **Backend:** A new endpoint, `/api/log-event`, has been added to `server.js`. This endpoint receives event data from the frontend and inserts it into the new `user_events` table.
- **Frontend:** JavaScript event listeners have been added to the frontend in `index.html`. These listeners call the `/api/log-event` endpoint whenever a user clicks on a sketch (either from the main page or the modal) or on a WhatsApp contact link.

This feature provides valuable insight into user engagement and a clear mechanism for artist billing.