### PR TITLE
feat: Fix mobile image panning and multiple UX issues

### DIFF
--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -115,6 +115,8 @@ const drawing = {
     isDraggingSkin: false,
     dragOffset: new THREE.Vector3(),
     skinPanBounds: { x: 0, y: 0 },
+    dragStartPoint: new THREE.Vector3(),
+    initialSkinPosition: new THREE.Vector3(),
     raycaster: new THREE.Raycaster(),
     pointer: new THREE.Vector2(),
     selectedArea: null,
@@ -317,8 +319,8 @@ const drawing = {
             const skinIntersects = drawing.raycaster.intersectObject(drawing.skinMesh);
             if (skinIntersects.length > 0) {
                 drawing.isDraggingSkin = true;
-                const intersectPoint = skinIntersects[0].point;
-                drawing.dragOffset.copy(intersectPoint).sub(drawing.skinMesh.position);
+                drawing.dragStartPoint.copy(skinIntersects[0].point);
+                drawing.initialSkinPosition.copy(drawing.skinMesh.position);
             }
         }
     },
@@ -336,13 +338,14 @@ const drawing = {
                 drawing.tattooMesh.position.copy(intersect).sub(drawing.dragOffset);
             }
         } else if (drawing.isDraggingSkin) {
-            const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0); // Plane at z=0
+            const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
             const intersect = new THREE.Vector3();
             if (drawing.raycaster.ray.intersectPlane(plane, intersect)) {
-                drawing.skinMesh.position.copy(intersect).sub(drawing.dragOffset);
-                // Clamp position
-                drawing.skinMesh.position.x = THREE.MathUtils.clamp(drawing.skinMesh.position.x, -drawing.skinPanBounds.x, drawing.skinPanBounds.x);
-                drawing.skinMesh.position.y = THREE.MathUtils.clamp(drawing.skinMesh.position.y, -drawing.skinPanBounds.y, drawing.skinPanBounds.y);
+                const delta = new THREE.Vector3().copy(intersect).sub(drawing.dragStartPoint);
+                const newPosition = new THREE.Vector3().copy(drawing.initialSkinPosition).add(delta);
+
+                drawing.skinMesh.position.x = THREE.MathUtils.clamp(newPosition.x, -drawing.skinPanBounds.x, drawing.skinPanBounds.x);
+                drawing.skinMesh.position.y = THREE.MathUtils.clamp(newPosition.y, -drawing.skinPanBounds.y, drawing.skinPanBounds.y);
             }
         }
     },


### PR DESCRIPTION
This commit addresses several issues, including a problem with tattoo scaling in the FLUX API and various mobile user experience enhancements.

- Implements a "donut" mask for FLUX API calls to preserve the tattoo's size and angle during inpainting. This is controlled by a `LOCK_SILHOUETTE` environment variable.
- Implements panning for the background skin image in the drawing canvas, allowing users to view different parts of large images on mobile.
- Fixes a "jumping" issue when pinching to resize a tattoo by refining the touch event handling logic.
- Adds a loading indicator that displays while style tattoos are being fetched.
- Removes the 5MB file size check for uploaded images, allowing them to be resized instead of rejected.
- Fixes a syntax error by removing a duplicate declaration of the 'engine' constant.
- Fixes a bug where the skin image could not be dragged/panned.