### PR TITLE
fix: Show drawing section after skin photo upload

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -864,6 +864,7 @@
                 STATE.currentImage = resizedFile;
 
                 skinPhotoUploadSection.style.display = 'none';
+                document.getElementById('drawingSection').style.display = 'block';
 
                 if (window.drawing && drawing.init) {
                     const tattooImageUrl = STATE.selectedStencil ? STATE.selectedStencil.imageUrl : STATE.uploadedTattooDesignBase64;


### PR DESCRIPTION
This commit fixes a regression where the drawing section, containing the canvas, was not being made visible after a user uploaded a skin photo. The `handleSkinPhotoFile` function was correctly processing the image but failed to update the UI to show the drawing canvas.

A line of JavaScript has been added to set the `display` style of the `#drawingSection` to 'block', ensuring the user can proceed to the tattoo placement step.