### PR TITLE
feat: Implement client-side background removal via ImageMagick

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -248,21 +248,34 @@
     <script type="module">
         console.log('Main inline script starting...');
 
-        const { call } = await import('https://cdn.jsdelivr.net/npm/wasm-imagemagick/dist/bundles/magick.es.js');
+        // Pin to a specific version
+        const MAGICK_BASE = 'https://cdn.jsdelivr.net/npm/wasm-imagemagick@1.2.0/dist/';
+        // (magickApi.js will fetch magick.js and magick.wasm from this same folder)
+        const { buildInputFile, execute } = await import('https://cdn.jsdelivr.net/npm/wasm-imagemagick@1.2.0/dist/magickApi.js');
 
-        async function cleanWithMagick(urlOrDataUrl) {
-          const ab = await (await fetch(urlOrDataUrl, { mode: 'cors' })).arrayBuffer();
-          const files = [{ name: 'in.png', content: new Uint8Array(ab) }];
+        // Make it reachable from your inline code if you prefer:
+        window.Magick = { buildInputFile, execute };
 
-          // -fuzz 10% lets “almost white” go transparent; tweak 5–20% as needed
-          const { outputFiles } = await call(files, ['convert', 'in.png',
-            '-fuzz', '10%', '-transparent', 'white', '-alpha', 'on', 'out.png'
-          ]);
+        async function stripStencilBackground(urlOrDataUrl) {
+            // Ensure we have a Blob (avoid tainted canvas; works even for cross-origin stencils)
+            const srcBlob = await (await fetch(urlOrDataUrl, { mode: 'cors' })).blob();
 
-          const out = outputFiles[0];
-          const blob = new Blob([out.content], { type: 'image/png' });
-          return URL.createObjectURL(blob); // or convert to dataURL if you prefer
+            // Build IM input file from blob
+            const inputFile = await window.Magick.buildInputFile(srcBlob, 'stencil.png');
+
+            // Convert near-white background to transparent; tweak fuzz % as needed
+            const { outputFiles } = await window.Magick.execute({
+              inputFiles: [inputFile],
+              commands: [
+                'convert stencil.png -alpha on -fuzz 10% -transparent white out.png'
+              ]
+            });
+
+            // Return a same-origin blob URL you can feed to <img> safely
+            return URL.createObjectURL(outputFiles[0].blob);
         }
+
+        window.stripStencilBackground = stripStencilBackground;
 
         async function logUserEvent(eventType, artistId, stencilId) {
             if (!STATE.token) return; // Don't log events for anonymous users
@@ -883,13 +896,19 @@
                 document.getElementById('drawingSection').style.display = 'block';
 
                 if (window.drawing && drawing.init) {
-                    const tattooImageUrl = STATE.selectedStencil ? STATE.selectedStencil.imageUrl : STATE.uploadedTattooDesignBase64;
+                    let tattooImageUrl = STATE.selectedStencil ? STATE.selectedStencil.imageUrl : STATE.uploadedTattooDesignBase64;
                     if (!tattooImageUrl) {
                         utils.showError('No stencil selected or uploaded. Please go back and choose a stencil or upload one.');
                         return;
                     }
+
+                    // Clean background before initializing the drawing canvas
+                    utils.showLoading('Cleaning tattoo background...');
+                    const cleanedTattooUrl = await window.stripStencilBackground(tattooImageUrl);
+                    utils.hideLoading();
+
                     // Pass both skin and tattoo image URLs to the new init function
-                    drawing.init(resizedDataURL, tattooImageUrl);
+                    drawing.init(resizedDataURL, cleanedTattooUrl);
                 } else {
                     console.error("drawing.js module not loaded correctly or 'drawing' object not exposed.");
                 }


### PR DESCRIPTION
This commit implements a robust, client-side solution for removing tattoo backgrounds, following a detailed implementation provided by the user. This resolves the persistent issue of tattoo backgrounds appearing on the canvas.

The previous backend-based background removal has been replaced. The application now uses a WASM version of ImageMagick, loaded from a CDN, to process the tattoo image directly in the browser before it is rendered.

Key changes:
- **ImageMagick Integration:** A new module script in `index.html` imports the `magickApi.js` library from a version-pinned CDN URL. A new helper function, `stripStencilBackground`, uses ImageMagick to convert white and near-white backgrounds to transparent with a 10% fuzz factor.
- **Updated Drawing Flow:** The `drawing.init` call in `index.html` is now preceded by a call to `stripStencilBackground`, ensuring the canvas in `drawing.js` only ever receives a cleaned, background-free tattoo image. The `drawing.js` `init` function has been simplified accordingly.
- **Backend Submission:** The logic that sends the final image to the backend for AI processing has been updated to use the cleaned version of the tattoo.
- **Canvas Stability:** The `drawing-container` CSS now has a defined, responsive height, and a `ResizeObserver` has been added to `drawing.js` to keep the canvas buffer sharp and correctly sized, fixing the "skin not showing" bug.
- **Relative Tattoo Scaling:** The tattoo sizing slider is now relative to a sensible base scale, fixing the "tattoo is huge" bug.
- **CORS & Backend:** `crossOrigin` attributes have been added to image loads, and a `ReferenceError` in the backend was fixed.

This commit implements the user's expert solution to address all known remaining bugs.