### PR TITLE
fix: Revert to using original frontend mask for FLUX API

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -495,8 +495,6 @@ const fluxPlacementHandler = {
 
     // Solid BW + small feather
     const bwMask = await makeBinaryBWMask(originalMaskBuffer);
-    const fluxMaskPNG = await featherMask(bwMask, 0.8);
-    const maskForFluxB64 = fluxMaskPNG.toString('base64');
 
     let maskMeta, maskGrayRaw;
     try {
@@ -586,7 +584,7 @@ const fluxPlacementHandler = {
       const fillPayloads = buildFillPayloads({
         prompt: basePrompt,
         inputBase64,
-        maskBase64: maskForFluxB64,
+        maskBase64: maskBase64, // Use the original mask for the API call
         seed,
         guidance: 5.5
       });
@@ -609,7 +607,7 @@ const fluxPlacementHandler = {
         const kontextPayloads = buildFillPayloads({
           prompt: basePrompt,
           inputBase64,
-          maskBase64: maskForFluxB64,
+          maskBase64: maskBase64, // Use the original mask for the API call
           seed,
           guidance: 5.5
         });


### PR DESCRIPTION
This commit reverts a previous change that was generating a new solid black-and-white mask for the FLUX API call. The new mask generation was causing the entire image to be edited, rather than just the intended tattoo area.

The `placeTattooOnSkin` function in `backend/modules/fluxPlacementHandler.js` has been modified to pass the original, unmodified `maskBase64` from the frontend to the FLUX API payload.

The logic to create a binary black-and-white mask (`bwMask`) has been preserved, as it is still required by the `buildEdgeRingMaskPNG` helper function for the subsequent edge-anchoring step. This ensures the final tattoo size and shape are preserved while fixing the incorrect inpainting area.