### PR TITLE
fix: Add error handling to user stencil upload

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -754,7 +754,13 @@
                 reader.onload = async (e) => {
                     const originalDataURL = e.target.result;
                     const resizedDataURL = await resizeImage(originalDataURL, file.type, 768, 768, 0.9);
-                    STATE.uploadedTattooDesignBase64 = await cleanStencilWhiteBg(resizedDataURL);
+
+                    try {
+                        STATE.uploadedTattooDesignBase64 = await cleanStencilWhiteBg(resizedDataURL);
+                    } catch (err) {
+                        console.warn('BG clean failed for uploaded stencil; using original:', err);
+                        STATE.uploadedTattooDesignBase64 = resizedDataURL; // Fallback
+                    }
 
                     document.getElementById('styleSelectionSection').style.display = 'none';
                     document.getElementById('skinPhotoUploadSection').style.display = 'block';


### PR DESCRIPTION
This commit fixes a bug where the application flow would break if a user-uploaded stencil failed the background cleaning process.

The `handleTattooDesignFile` function in `index.html` has been updated to include a `try...catch` block around the call to `cleanStencilWhiteBg`. If the cleaning function throws an error for any reason, it is now caught, a warning is logged to the console, and the application falls back to using the original, uncleaned (but resized) version of the uploaded image.

This makes the user upload feature more resilient and ensures the user can always proceed to the placement step, even if background removal fails.