### PR TITLE
fix: Clear selected stencil state on user upload

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -761,6 +761,7 @@
                         console.warn('BG clean failed for uploaded stencil; using original:', err);
                         STATE.uploadedTattooDesignBase64 = resizedDataURL; // Fallback
                     }
+                    STATE.selectedStencil = null; // Clear any gallery selection
 
                     document.getElementById('styleSelectionSection').style.display = 'none';
                     document.getElementById('skinPhotoUploadSection').style.display = 'block';


### PR DESCRIPTION
This commit fixes a bug where a user-uploaded stencil would not be displayed on the canvas if a gallery stencil had been selected previously.

The application state was not being cleared correctly. When a user uploads their own design, the state for the previously selected gallery stencil (`STATE.selectedStencil`) was persisting. The logic for choosing which tattoo to display prioritized the gallery selection, so the user's upload was ignored.

The `handleTattooDesignFile` function in `index.html` has been modified to set `STATE.selectedStencil = null` after a user-uploaded stencil is successfully processed. This ensures the application correctly prioritizes the user's own design.