### PR TITLE
fix(backend): Remove incorrect fallback to kontext API

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -591,33 +591,13 @@ const fluxPlacementHandler = {
       // prefer inpaint/fill. If you still want kontext fallback, try that afterward.
       const endpoints = FLUX_ENDPOINTS.fill;
 
-      let task;
-      try {
-        const r = await callFluxFillTryAll({
-          key: fluxApiKey || FLUX_API_KEY,
-          endpoints,
-          payloads: fillPayloads
-        });
-        task = r.data;
-        console.log(`DEBUG: FLUX POST ok via ${r.url} id=${task.id || '(no id)'}`);
-      } catch (e) {
-        // optional: try kontext as a second chance
-        console.warn('Fill failed, trying kontext...', e.message);
-        const kontextPayloads = buildFillPayloads({
-          prompt: basePrompt,
-          inputBase64,
-          maskBase64: maskBase64, // Use the original mask for the API call
-          seed,
-          guidance: 5.5
-        });
-        const r2 = await callFluxFillTryAll({
-          key: fluxApiKey || FLUX_API_KEY,
-          endpoints: FLUX_ENDPOINTS.kontext,
-          payloads: kontextPayloads
-        });
-        task = r2.data;
-        console.log(`DEBUG: FLUX KONTEST POST ok via ${r2.url} id=${task.id || '(no id)'}`);
-      }
+      const r = await callFluxFillTryAll({
+        key: fluxApiKey || FLUX_API_KEY,
+        endpoints,
+        payloads: fillPayloads
+      });
+      const task = r.data;
+      console.log(`DEBUG: FLUX POST ok via ${r.url} id=${task.id || '(no id)'}`);
 
       if (task?.result?.sample) {
         const url = task.result.sample;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1010,6 +1010,7 @@
             STATE.currentMask = drawing.selectedArea;
 
             // --- Display artist info in loading overlay ---
+            console.log('DEBUG: Checking for artist info. STATE.selectedStencil:', STATE.selectedStencil);
             const artistInfo = document.getElementById('artistInfo');
             const artistName = document.getElementById('artistName');
             const artistSketchesGrid = document.getElementById('artistSketchesGrid');


### PR DESCRIPTION
This commit fixes a critical bug where the wrong tattoo was being generated by the FLUX API.

The root cause was an incorrect `try...catch` block that attempted to fall back to the `kontext` API endpoints if the primary `fill` endpoints failed. The `fill` endpoints were failing with a `404 Not Found`, and the `kontext` endpoint that was succeeding was not designed for the inpainting task, resulting in a completely different tattoo being generated.

This commit removes the fallback logic entirely. The pipeline will now correctly use only the `fill` endpoints as intended for this workflow, and will surface an error if they fail. This ensures the correct AI model is used and prevents incorrect tattoos from being generated.