### PR TITLE
fix(backend): Restore getMaskBBox helper function

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -327,6 +327,23 @@ const fluxPlacementHandler = {
     const maskMeta = await sharp(originalMaskBuffer).metadata();
     const maskGrayRaw = await sharp(originalMaskBuffer).grayscale().raw().toBuffer();
 
+    function getMaskBBox(buf, w, h) {
+      let minX = w, minY = h, maxX = -1, maxY = -1, found = false;
+      for (let y = 0; y < h; y++) {
+        const row = y * w;
+        for (let x = 0; x < w; x++) {
+          if (buf[row + x] > 0) {
+            found = true;
+            if (x < minX) minX = x;
+            if (y < minY) minY = y;
+            if (x > maxX) maxX = x;
+            if (y > maxY) maxY = y;
+          }
+        }
+      }
+      if (!found) return { isEmpty: true };
+      return { isEmpty: false, minX, minY, maxX, maxY, width: maxX - minX + 1, height: maxY - minY + 1 };
+    }
     const maskBBox = getMaskBBox(maskGrayRaw, maskMeta.width, maskMeta.height);
     if (maskBBox.isEmpty) throw new Error('Mask area is empty.');
 


### PR DESCRIPTION
This commit fixes a `ReferenceError: getMaskBBox is not defined` in `fluxPlacementHandler.js`.

The helper function `getMaskBBox` was mistakenly removed during a previous refactoring/reverting of the backend logic, but the `placeTattooOnSkin` function still depended on it.

This commit restores the `getMaskBBox` function to its original location inside `placeTattooOnSkin`, resolving the backend crash.