### PR TITLE
Fix syntax error in basePrompt string

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -368,7 +368,7 @@ const fluxPlacementHandler = {
 
     const generatedImageUrls = [];
     //const basePrompt = 'Preserve the exact silhouette, linework, proportions and interior details of the tattoo. Only relight and blend the existing tattoo into the skin. Add realistic lighting, micro-shadowing, slight ink diffusion, and subtle skin texture. Do not redraw or restyle.';
-    const basePrompt = 'put the tattoo over the woman's arm. make it look like a real life tattoo. adjust lighting etc.';
+    const basePrompt = "put the tattoo over the woman's arm. make it look like a real life tattoo. adjust lighting etc.";
     const fluxHeaders = { 'Content-Type': 'application/json', 'x-key': fluxApiKey || FLUX_API_KEY };
     const endpoint = engine === 'fill' ? 'https://api.bfl.ai/v1/flux-fill' : 'https://api.bfl.ai/v1/flux-kontext-pro';
     const inputBase64 = compositedForPreview.toString('base64');


### PR DESCRIPTION
The `basePrompt` constant in `fluxPlacementHandler.js` was defined using single quotes, but it contained a single quote (apostrophe) which caused a `SyntaxError`.

This commit changes the string to be enclosed in double quotes to resolve the syntax error.