### PR TITLE
Fix: Reset stencil file input on new design

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -849,6 +849,7 @@
                 if (artistsSection) artistsSection.style.display = 'none';
                 if (socialShareDiv) socialShareDiv.style.display = 'none';
                 if (fileInput) fileInput.value = '';
+                if (stencilFileInput) stencilFileInput.value = '';
 
 
                 if (window.drawing && drawing.clearCanvas) {


### PR DESCRIPTION
The `stencilFileInput` element was not being reset when the user started a new design. This meant that if the user tried to upload the same stencil file again, the `change` event would not fire, and the application would appear to be stuck.

This commit adds a line to the `resetUI` function to clear the value of the `stencilFileInput`, ensuring that the `change` event is always triggered when a file is selected.