### PR TITLE
fix: Correct Flux API payload for tattoo generation

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -389,15 +389,14 @@ const fluxPlacementHandler = {
     for (let i = 0; i < numVariations; i++) {
       const seed = Date.now() + i;
 
-      // [CHANGED] lower guidance + disable prompt_upsampling to reduce creativity
+      // [FIXED] payload structure to match API documentation
       const payload = {
         prompt: basePrompt,
-        input_image: inputBase64,
-        mask_image: maskBase64Fixed,
+        image: inputBase64,
+        mask: maskBase64Fixed,
         output_format: 'png',
-        n: 1,
-        guidance_scale: 4.0,       // [CHANGED]
-        prompt_upsampling: false,  // [CHANGED]
+        steps: 50,
+        guidance: 30,
         safety_tolerance: 2,
         seed
       };


### PR DESCRIPTION
The payload sent to the Flux API was incorrect, causing a 'Field required' error. This change updates the payload to match the official Flux API documentation by renaming fields and adjusting parameters.