### PR TITLE
fix(backend): Correct buffer type for sharp alpha channel

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -39,7 +39,7 @@ async function buildWeightedMaskFromPositioned(positionedCanvasPNG) {
   const meta = await sharp(positionedCanvasPNG).metadata();
   const w = meta.width, h = meta.height;
 
-  const alpha = await sharp(positionedCanvasPNG).ensureAlpha().extractChannel('alpha').toBuffer();
+  const alpha = await sharp(positionedCanvasPNG).ensureAlpha().extractChannel('alpha').raw().toBuffer();
   const hard = await sharp(alpha, { raw: { width: w, height: h, channels: 1 } }).threshold(1).raw().toBuffer();
 
   const dilated = await sharp(hard, { raw: { width: w, height: h, channels: 1 } }).blur(1.6).threshold(1).raw().toBuffer();


### PR DESCRIPTION
The `buildWeightedMaskFromPositioned` function was passing a PNG-encoded buffer to a sharp constructor that expected raw pixel data. This caused a 'VipsImage: memory area too small' error because the encoded buffer was smaller than the expected raw buffer size.

This fix adds the `.raw()` method when extracting the alpha channel to ensure the buffer contains uncompressed pixel data, matching the expectation of the subsequent sharp operation.