### PR TITLE
fix(backend): Use morphology operator for robust erosion

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -44,7 +44,7 @@ async function buildWeightedMaskFromPositioned(positionedCanvasPNG) {
 
   const dilated = await sharp(hard, { raw: { width: w, height: h, channels: 1 } }).blur(1.6).threshold(1).raw().toBuffer();
 
-  const eroded  = await sharp(hard, { raw: { width: w, height: h, channels: 1 } }).blur(1.0).threshold(128).raw().toBuffer();
+  const eroded  = await sharp(hard, { raw: { width: w, height: h, channels:1 } }).morphology('erode', sharp.kernel('square', 3)).raw().toBuffer();
 
   const N = w * h;
   const ring   = Buffer.alloc(N);


### PR DESCRIPTION
The previous attempts to fix the black image issue by tuning the `blur().threshold()` parameters were not successful. This method of erosion is not reliable and continued to produce black/transparent masks.

This commit replaces the `blur().threshold()` logic entirely with `sharp.morphology('erode', ...)`. This uses a proper morphological operator which is much more reliable and predictable for shrinking the silhouette mask. This should definitively resolve the issue of black images being generated.