### PR TITLE
fix(backend): Use correct kernel definition for morphology

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -44,7 +44,7 @@ async function buildWeightedMaskFromPositioned(positionedCanvasPNG) {
 
   const dilated = await sharp(hard, { raw: { width: w, height: h, channels: 1 } }).blur(1.6).threshold(1).raw().toBuffer();
 
-  const eroded  = await sharp(hard, { raw: { width: w, height: h, channels:1 } }).morphology('erode', sharp.kernel('square', 3)).raw().toBuffer();
+  const eroded  = await sharp(hard, { raw: { width: w, height: h, channels:1 } }).morphology('erode', { width: 3, height: 3, data: [1,1,1,1,1,1,1,1,1] }).raw().toBuffer();
 
   const N = w * h;
   const ring   = Buffer.alloc(N);


### PR DESCRIPTION
The previous commit introduced a `TypeError: sharp.kernel is not a function` because the `sharp.kernel()` static method is not available in the installed version of `sharp` (0.33.4).

This commit corrects the error by replacing the non-existent function call with a manually defined kernel object, which is the correct syntax for this version. This resolves the crash and provides the robust erosion functionality needed to finally fix the underlying issue of generated images appearing black.