### PR TITLE
Fix(frontend): Display message when no styles are loaded

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -546,6 +546,23 @@
                         throw new Error('Failed to fetch stencil data');
                     }
                     stencilData = await response.json();
+
+                    // --- NEW: Handle case where no styles are returned ---
+                    if (!stencilData || Object.keys(stencilData).length === 0) {
+                        console.warn('Backend returned no stencil data. Displaying message to user.');
+                        const styleSelectionSection = document.getElementById('styleSelectionSection');
+                        if (styleSelectionSection) {
+                            styleSelectionSection.innerHTML = `
+                                <div class="section-header">
+                                    <h2>Styles Unavailable</h2>
+                                    <p>We couldn't load any tattoo styles at the moment. This could be a temporary issue. Please try refreshing the page in a little while.</p>
+                                </div>
+                            `;
+                        }
+                        return; // Stop execution to prevent errors
+                    }
+                    // --- END NEW ---
+
                     populateStyleChips();
                 } catch (error) {
                     console.error('Error fetching stencil data:', error);


### PR DESCRIPTION
When the `/api/styles-with-stencils` endpoint returns an empty object, the frontend would silently fail to populate the style selection section, leaving a blank space in the UI.

This commit adds a defensive check in the `fetchStencilData` function in `index.html`. If the fetched data is empty, the function will now:
1. Log a warning to the console for developers.
2. Replace the content of the `styleSelectionSection` with a user-friendly message explaining that styles could not be loaded.
3. Stop further execution of the function to prevent any potential downstream errors.

This makes the UI more robust and provides clear feedback to the user if there's an issue with loading the style data.