### PR TITLE
Fix: Increase FLUX API timeout and make it configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsI
 # Flux API Configuration
 FLUX_API_KEY=YOUR_FLUX_API_KEY_HERE
 FLUX_API_URL=https://api.bfl.ml/v1
+# Timeout for the main FLUX API POST request in milliseconds. Defaults to 180000 (3 minutes).
+FLUX_MAIN_POST_TIMEOUT_MS=180000
 
 # Stripe Configuration (for future use)
 STRIPE_PUBLIC_KEY=YOUR_STRIPE_PUBLIC_KEY_HERE

--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -28,6 +28,7 @@ const ADAPTIVE_SCALE_ENABLED  = (process.env.ADAPTIVE_SCALE_ENABLED  ?? 'true').
 const ADAPTIVE_ENGINE_ENABLED = (process.env.ADAPTIVE_ENGINE_ENABLED ?? 'true').toLowerCase() === 'true';
 const GLOBAL_SCALE_UP         = Number(process.env.MODEL_SCALE_UP || '1.0');          // applied always
 const FLUX_ENGINE_DEFAULT     = (process.env.FLUX_ENGINE || 'kontext').toLowerCase(); // 'kontext' | 'fill'
+const FLUX_MAIN_POST_TIMEOUT_MS = Number(process.env.FLUX_MAIN_POST_TIMEOUT_MS || '180000');
 
 // Engine-specific size bias to counter model shrink
 const ENGINE_KONTEXT_SIZE_BIAS = Number(process.env.ENGINE_KONTEXT_SIZE_BIAS || '1.08');
@@ -540,7 +541,7 @@ const fluxPlacementHandler = {
 
       let task;
       try {
-        const res = await axios.post(endpoint, payload, { headers: fluxHeaders, timeout: 90000 });
+        const res = await axios.post(endpoint, payload, { headers: fluxHeaders, timeout: FLUX_MAIN_POST_TIMEOUT_MS });
         task = res.data;
         console.log(`DEBUG: FLUX POST status=${res.status} id=${task.id}`);
       } catch (e) {


### PR DESCRIPTION
The FLUX API was timing out after 90 seconds. This change increases the default timeout to 180 seconds and makes it configurable via the `FLUX_MAIN_POST_TIMEOUT_MS` environment variable.