### PR TITLE
feat: Increase default tattoo size by 50%

### DIFF
--- a/backend/modules/fluxPlacementHandler.js
+++ b/backend/modules/fluxPlacementHandler.js
@@ -26,7 +26,7 @@ const FLUX_API_KEY = process.env.FLUX_API_KEY;
 // -----------------------------
 const ADAPTIVE_SCALE_ENABLED  = (process.env.ADAPTIVE_SCALE_ENABLED  ?? 'true').toLowerCase() === 'true';
 const ADAPTIVE_ENGINE_ENABLED = (process.env.ADAPTIVE_ENGINE_ENABLED ?? 'true').toLowerCase() === 'true';
-const GLOBAL_SCALE_UP         = Number(process.env.MODEL_SCALE_UP || '1.0');          // applied always
+const GLOBAL_SCALE_UP         = Number(process.env.MODEL_SCALE_UP || '1.5');          // applied always
 const FLUX_ENGINE_DEFAULT     = (process.env.FLUX_ENGINE || 'kontext').toLowerCase(); // 'kontext' | 'fill'
 
 // Engine-specific size bias to counter model shrink


### PR DESCRIPTION
The default value for GLOBAL_SCALE_UP has been increased from 1.0 to 1.5 in backend/modules/fluxPlacementHandler.js.

This change addresses the recurring issue of tattoos appearing smaller than expected by increasing their size by 50% before being sent to the Flux API.