### PR TITLE
fix: Remove unnecessary jwt_decode call in admin.js

### DIFF
--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -11,8 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    const decodedToken = jwt_decode(STATE.token);
-    if (!decodedToken || !STATE.user.is_admin) {
+    if (!STATE.user || !STATE.user.is_admin) {
          alert('You are not authorized to view this page.');
          window.location.href = 'index.html';
          return;


### PR DESCRIPTION
This commit fixes a critical JavaScript error that prevented the admin dashboard from loading. The `admin.js` script was calling `jwt_decode`, which was not defined on the page, causing a `ReferenceError`. This error halted script execution and led to an incorrect authorization check, redirecting the user away from the page.

The `jwt_decode` call was redundant, as the necessary `is_admin` flag is already present in the `STATE.user` object loaded from local storage. By removing this unnecessary and crashing line, the script can now execute correctly, properly verifying the user's admin status and allowing the dashboard to load as intended.