### PR TITLE
debug: Add detailed logging to presets endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -638,14 +638,20 @@ app.post('/api/admin/flux-settings/rollback/:history_id', authenticateToken, isA
 // --- Preset Management Endpoints ---
 app.get('/api/admin/presets', authenticateToken, isAdmin, async (req, res) => {
     try {
+        console.log('Fetching presets...');
         const { data, error } = await supabase
             .from('flux_presets')
             .select('*')
             .order('created_at', { ascending: false });
 
-        if (error) throw error;
+        if (error) {
+            console.error('Error fetching presets:', error);
+            throw error;
+        }
+        console.log('Presets fetched successfully:', data);
         res.json(data);
     } catch (error) {
+        console.error('Caught error in /api/admin/presets:', error);
         res.status(500).json({ error: 'Failed to fetch presets' });
     }
 });


### PR DESCRIPTION
This commit adds more detailed logging to the `/api/admin/presets` endpoint to diagnose a 500 Internal Server Error. This will help identify the root cause of the issue by providing more information about the Supabase query and any potential errors.