### PR TITLE
fix: Implement responsive canvas sizing in admin tool

### DIFF
--- a/frontend/js/admin_drawing.js
+++ b/frontend/js/admin_drawing.js
@@ -23,8 +23,13 @@ const adminDrawing = {
         this.tattooImage.crossOrigin = "Anonymous";
 
         this.skinImage.onload = () => {
-            this.canvas.width = this.skinImage.width;
-            this.canvas.height = this.skinImage.height;
+            const parent = this.canvas.parentElement;
+            const parentWidth = parent.clientWidth;
+            const scale = parentWidth / this.skinImage.naturalWidth;
+
+            this.canvas.width = this.skinImage.naturalWidth * scale;
+            this.canvas.height = this.skinImage.naturalHeight * scale;
+
             this.tattooPos = { x: this.canvas.width / 2, y: this.canvas.height / 2 };
             this.draw();
         };
@@ -68,7 +73,7 @@ const adminDrawing = {
         if (!this.skinImage || !this.tattooImage) return;
 
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        this.ctx.drawImage(this.skinImage, 0, 0);
+        this.ctx.drawImage(this.skinImage, 0, 0, this.canvas.width, this.canvas.height);
 
         this.ctx.save();
         this.ctx.translate(this.tattooPos.x, this.tattooPos.y);


### PR DESCRIPTION
This commit fixes a major usability issue in the admin page's hill climbing tool where the skin image was not being resized correctly, making it impossible to position the tattoo.

The `admin_drawing.js` module has been updated to replicate the responsive canvas logic from the main application. It now:
- Calculates the correct canvas dimensions based on the parent container's width and the skin image's aspect ratio.
- Draws the skin image scaled to fit the new, responsive canvas dimensions.

This ensures the entire skin image is visible and the interactive tattoo placement works as expected, matching the user experience of the main application.