### PR TITLE
fix: Update CORS policy to allow admin frontend origin

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -57,7 +57,8 @@ app.use(cors({
         process.env.FRONTEND_URL,
         'https://itayash22.github.io',
         'http://localhost:8080',
-        'http://127.0.0.1:8080'
+        'http://127.0.0.1:8080',
+        'https://itayash22.github.io/slatetattoo-frontend/'
     ],
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
This commit fixes a Cross-Origin Resource Sharing (CORS) issue that was preventing the admin dashboard from fetching data from the backend.

The backend's CORS configuration has been updated to explicitly include the frontend's origin (`https://itayash22.github.io`). This ensures that the server will accept requests from the admin page, resolving the `No 'Access-Control-Allow-Origin' header` errors and allowing the dashboard to function correctly.