### PR TITLE
Fix: Implement robust resizing for skin image container

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -356,7 +356,10 @@ body {
   min-height:360px;
   background:#111;
   overflow:hidden;
-  max-width: 100%;
+  max-width: 800px;        /* or any comfortable working width */
+  max-height: 600px;       /* cap height so it doesn’t fill the whole viewport */
+  margin: 0 auto;          /* center horizontally */
+  border: 1px solid #ccc;  /* optional visual frame */
 }
 
 /* ensures CSS size always matches the JS pixel buffer */

--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -128,10 +128,9 @@ function centerSkin() {
   const cw = canvas.width, ch = canvas.height;
   const sw = skinImg.width, sh = skinImg.height;
 
-  // fit width by default (you already resized to ~768, but mobile DPR may vary)
+  // contain-fit but also cap scale so large screens don't blow up image
   const scaleX = cw / sw, scaleY = ch / sh;
-  camera.scale = Math.min(scaleX, scaleY); // contain-fit
-  // place centered
+  camera.scale = Math.min(scaleX, scaleY, 1);  // 👈 new limit: never scale above 1:1
   camera.x = (cw - sw * camera.scale) * 0.5;
   camera.y = (ch - sh * camera.scale) * 0.5;
 }


### PR DESCRIPTION
This commit resolves an issue where the skin image could appear too large on the dashboard. The fix is two-fold:

1.  In `frontend/css/styles.css`, the `.drawing-container` is now constrained with a `max-width` and `max-height`. This prevents the container from expanding to fill the entire viewport on larger screens.

2.  In `frontend/js/drawing.js`, the `centerSkin` function is updated to cap the camera's scale factor at 1. This ensures the skin image is never scaled up beyond its original resolution, preventing pixelation and ensuring it fits correctly within its container.

Together, these changes provide a robust solution that correctly sizes the skin image for a better user experience.