### PR TITLE
Fix: Ensure skin image scales to fit container

### DIFF
--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -128,9 +128,10 @@ function centerSkin() {
   const cw = canvas.width, ch = canvas.height;
   const sw = skinImg.width, sh = skinImg.height;
 
-  // contain-fit but also cap scale so large screens don't blow up image
+  // fit width by default (you already resized to ~768, but mobile DPR may vary)
   const scaleX = cw / sw, scaleY = ch / sh;
-  camera.scale = Math.min(scaleX, scaleY, 1);  // 👈 new limit: never scale above 1:1
+  camera.scale = Math.min(scaleX, scaleY); // contain-fit
+  // place centered
   camera.x = (cw - sw * camera.scale) * 0.5;
   camera.y = (ch - sh * camera.scale) * 0.5;
 }


### PR DESCRIPTION
This commit ensures that the skin image loaded by the user always scales to fit the drawing container.

The `centerSkin` function in `frontend/js/drawing.js` was modified to use `Math.min(scaleX, scaleY)` for the camera scale. This ensures the image will scale up or down as needed to be fully visible within the container.

Additionally, the `.drawing-container` in `frontend/css/styles.css` has its `max-width` and `max-height` set to provide a reasonably sized drawing area on larger screens.