### PR TITLE
Fix: Correct image scaling using logical pixels

### DIFF
--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -123,17 +123,25 @@ function init(skinDataURL, cleanedTattooUrl) {
 }
 
 function centerSkin() {
-  // center the skin image at 1:1 scale if larger than canvas; adjust to fit width
   if (!skinImg || !skinImg.width) return;
-  const cw = canvas.width, ch = canvas.height;
-  const sw = skinImg.width, sh = skinImg.height;
 
-  // fit width by default (you already resized to ~768, but mobile DPR may vary)
-  const scaleX = cw / sw, scaleY = ch / sh;
-  camera.scale = Math.min(scaleX, scaleY); // contain-fit
-  // place centered
-  camera.x = (cw - sw * camera.scale) * 0.5;
-  camera.y = (ch - sh * camera.scale) * 0.5;
+  // Use CSS pixel dimensions, not internal buffer dimensions
+  const parent = canvas.parentElement;
+  const cw = parent.clientWidth;
+  const ch = parent.clientHeight;
+  const sw = skinImg.width;
+  const sh = skinImg.height;
+
+  // Compute scale so image fits entirely inside canvas area
+  const scaleX = cw / sw;
+  const scaleY = ch / sh;
+  camera.scale = Math.min(scaleX, scaleY);
+
+  // Center the image
+  camera.x = (cw * window.devicePixelRatio - sw * camera.scale * window.devicePixelRatio) * 0.5;
+  camera.y = (ch * window.devicePixelRatio - sh * camera.scale * window.devicePixelRatio) * 0.5;
+
+  requestRender();
 }
 
 function attachPanHandlers() {


### PR DESCRIPTION
The previous image scaling logic in `centerSkin()` used `canvas.width` and `canvas.height` for its calculations. These values are based on the device pixel ratio and do not represent the logical, on-screen size of the canvas. This caused the skin image to be scaled incorrectly, appearing too large on high-DPI (Retina) displays.

This commit replaces the `centerSkin` function with a new version that correctly calculates the scale using the `clientWidth` and `clientHeight` of the canvas's parent element. This ensures the scaling is based on logical pixels, making the image display correctly and consistently across all devices.

The function now also correctly centers the image within the canvas, taking the device pixel ratio into account for the final positioning. This resolves the sizing issue completely.