### PR TITLE
Feat: Make panning the default interaction mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -98,7 +98,7 @@
                     <button id="changeSkinPhotoBtn" class="btn btn-outline btn-sm">Change Skin Photo</button>
 
                     <!-- NEW: toggle pan mode -->
-                    <button id="togglePanBtn" class="btn btn-outline btn-sm">Move Skin</button>
+                    <button id="togglePanBtn" class="btn btn-outline btn-sm active">Done Moving Skin</button>
 
                     <div class="rotation-control">
                         <label for="rotationSlider">Rotate Tattoo: <span id="rotationValue">0°</span></label>
@@ -814,7 +814,7 @@
             const artistsSection = document.getElementById('artistsSection');
 
             const togglePanBtn = document.getElementById('togglePanBtn');
-            let panMode = false;
+            let panMode = true; // Start in pan mode by default
 
             togglePanBtn?.addEventListener('click', () => {
               panMode = !panMode;

--- a/frontend/js/drawing.js
+++ b/frontend/js/drawing.js
@@ -4,7 +4,7 @@
 let canvas, ctx;
 let skinImg = null, tattooImg = null; // assume you already set these in init
 const camera = { x: 0, y: 0, scale: 1 };
-let panMode = false;
+let panMode = true;
 
 let baseTattooScale = 1;
 


### PR DESCRIPTION
This commit changes the default interaction mode on the drawing canvas to panning. This allows users to immediately move the skin image upon upload, which is more intuitive when the image is larger than the container.

The `panMode` variable in `drawing.js` is now initialized to `true`. The UI in `index.html` has been updated to reflect this change, with the toggle button now defaulting to its active state ('Done Moving Skin').