### PR TITLE
Feat: Remove background from tattoo images on admin page

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -139,6 +139,7 @@
         }
     </script>
     <script src="js/auth.js"></script>
+    <script src="js/image-utils.js"></script>
     <script src="js/admin.js"></script>
     <script src="js/admin_drawing.js"></script>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -245,74 +245,11 @@
     <script src="js/config.js"></script>
     <script>console.log('Loading auth.js...');</script>
     <script src="js/auth.js"></script>
+    <script src="js/image-utils.js"></script>
     <script>console.log('Loading drawing.js...');</script>
     <script type="module" src="js/drawing.js"></script>
     <script type="module">
         console.log('Main inline script starting...');
-
-        // ---- White/near-white → alpha (no libs) ----
-        async function cleanStencilWhiteBg(urlOrDataUrl, { soft = 235, hard = 252 } = {}) {
-          // 1) Fetch as blob so we avoid tainted canvas (works for cross-origin URLs)
-          const resp = await fetch(urlOrDataUrl, { mode: 'cors' });
-          const srcBlob = await resp.blob();
-
-          // 2) Decode with EXIF orientation if possible
-          let bmpOrImg;
-          if ('createImageBitmap' in window) {
-            bmpOrImg = await createImageBitmap(srcBlob, { imageOrientation: 'from-image' });
-          } else {
-            bmpOrImg = await new Promise((resolve) => {
-              const im = new Image();
-              im.onload = () => resolve(im);
-              im.src = URL.createObjectURL(srcBlob);
-            });
-          }
-
-          const w = bmpOrImg.width || bmpOrImg.naturalWidth;
-          const h = bmpOrImg.height || bmpOrImg.naturalHeight;
-
-          // 3) Draw and read pixels
-          const c = document.createElement('canvas');
-          c.width = w; c.height = h;
-          const x = c.getContext('2d', { willReadFrequently: true });
-          x.clearRect(0, 0, w, h);
-          x.drawImage(bmpOrImg, 0, 0, w, h);
-
-          const imgData = x.getImageData(0, 0, w, h);
-          const d = imgData.data;
-
-          // Gentle white→alpha like your backend's colorToAlphaWhite()
-          const ramp = Math.max(1, hard - soft); // softness of the transition
-          for (let i = 0; i < d.length; i += 4) {
-            const R = d[i], G = d[i + 1], B = d[i + 2];
-            const A = d[i + 3];
-
-            const wmax = Math.max(R, G, B);
-            let alpha = A;
-
-            if (wmax >= soft) {
-              const cut = Math.max(0, Math.min(1, (wmax - soft) / ramp)); // 0..1
-              alpha = Math.round(A * (1 - cut));
-              if (wmax >= hard) alpha = 0;
-            }
-
-            // Decontaminate fringing: un-premultiply white from RGB where 0<alpha<255
-            if (alpha > 0 && alpha < 255) {
-              const a = alpha / 255;
-              d[i]     = Math.max(0, Math.min(255, Math.round((R - (1 - a) * 255) / a)));
-              d[i + 1] = Math.max(0, Math.min(255, Math.round((G - (1 - a) * 255) / a)));
-              d[i + 2] = Math.max(0, Math.min(255, Math.round((B - (1 - a) * 255) / a)));
-            }
-
-            d[i + 3] = alpha;
-          }
-
-          x.putImageData(imgData, 0, 0);
-
-          // 4) Return a safe, same-origin blob URL (PNG keeps transparency)
-          const blob = await new Promise(res => c.toBlob(res, 'image/png'));
-          return URL.createObjectURL(blob);
-        }
 
         async function logUserEvent(eventType, artistId, stencilId) {
             if (!STATE.token) return; // Don't log events for anonymous users
@@ -334,55 +271,6 @@
                 console.warn('Failed to log user event:', error);
             }
         }
-
-  async function resizeImage(dataURL, originalMimeType, maxWidth, maxHeight, quality = 0.9) {
-    // Turn dataURL into a Blob
-    const blob = await (await fetch(dataURL)).blob();
-
-    // Prefer createImageBitmap (applies EXIF orientation with the option below)
-    let sourceW, sourceH, draw;
-    if ('createImageBitmap' in window) {
-      const bitmap = await createImageBitmap(blob, { imageOrientation: 'from-image' });
-      sourceW = bitmap.width;
-      sourceH = bitmap.height;
-      draw = (ctx, w, h) => ctx.drawImage(bitmap, 0, 0, w, h);
-    } else {
-      // Fallback path
-      const img = await new Promise((resolve) => {
-        const im = new Image();
-        im.onload = () => resolve(im);
-        im.src = URL.createObjectURL(blob);
-      });
-      sourceW = img.width;
-      sourceH = img.height;
-      draw = (ctx, w, h) => ctx.drawImage(img, 0, 0, w, h);
-    }
-
-    // Contain-fit into the target box (no cropping)
-    const srcAR = sourceW / sourceH;
-    const boxAR = maxWidth / maxHeight;
-    let targetW, targetH;
-    if (srcAR > boxAR) {
-      targetW = maxWidth;
-      targetH = Math.round(maxWidth / srcAR);
-    } else {
-      targetH = maxHeight;
-      targetW = Math.round(maxHeight * srcAR);
-    }
-
-    const canvas = document.createElement('canvas');
-    canvas.width = targetW;
-    canvas.height = targetH;
-    const ctx = canvas.getContext('2d', { alpha: true });
-
-    ctx.clearRect(0, 0, targetW, targetH);
-    draw(ctx, targetW, targetH);
-
-    const outputMimeType = 'image/png';
-    const outputQuality = undefined; // Quality is only for JPEG
-
-    return canvas.toDataURL(outputMimeType, outputQuality);
-  }
 
 
         // --- Artist Loading and Filtering Functions (MOVED TO GLOBAL SCOPE) ---

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -238,7 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const currentTestInfo = document.getElementById('currentTestInfo');
     const lockAndTestNextBtn = document.getElementById('lockAndTestNext');
 
-    setupCanvasBtn.addEventListener('click', () => {
+    setupCanvasBtn.addEventListener('click', async () => {
         const tattooImageFile = document.getElementById('tattooImage').files[0];
         const skinImageFile = document.getElementById('skinImage').files[0];
 
@@ -253,8 +253,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const tattooUrl = URL.createObjectURL(tattooImageFile);
         const skinUrl = URL.createObjectURL(skinImageFile);
 
-        drawingSection.style.display = 'block';
-        adminDrawing.init('adminDrawingCanvas', skinUrl, tattooUrl);
+        // Clean the tattoo background before initializing the canvas
+        try {
+            const cleanedTattooUrl = await cleanStencilWhiteBg(tattooUrl);
+            drawingSection.style.display = 'block';
+            adminDrawing.init('adminDrawingCanvas', skinUrl, cleanedTattooUrl);
+        } catch (error) {
+            console.error("Failed to clean tattoo background:", error);
+            utils.showError("Could not process the tattoo image to remove the background.");
+        }
     });
 
     document.getElementById('adminRotationSlider').addEventListener('input', (e) => adminDrawing.setRotation(e.target.value));

--- a/frontend/js/image-utils.js
+++ b/frontend/js/image-utils.js
@@ -1,0 +1,114 @@
+// frontend/js/image-utils.js
+
+// ---- White/near-white → alpha (no libs) ----
+async function cleanStencilWhiteBg(urlOrDataUrl, { soft = 235, hard = 252 } = {}) {
+  // 1) Fetch as blob so we avoid tainted canvas (works for cross-origin URLs)
+  const resp = await fetch(urlOrDataUrl, { mode: 'cors' });
+  const srcBlob = await resp.blob();
+
+  // 2) Decode with EXIF orientation if possible
+  let bmpOrImg;
+  if ('createImageBitmap' in window) {
+    bmpOrImg = await createImageBitmap(srcBlob, { imageOrientation: 'from-image' });
+  } else {
+    bmpOrImg = await new Promise((resolve) => {
+      const im = new Image();
+      im.onload = () => resolve(im);
+      im.src = URL.createObjectURL(srcBlob);
+    });
+  }
+
+  const w = bmpOrImg.width || bmpOrImg.naturalWidth;
+  const h = bmpOrImg.height || bmpOrImg.naturalHeight;
+
+  // 3) Draw and read pixels
+  const c = document.createElement('canvas');
+  c.width = w; c.height = h;
+  const x = c.getContext('2d', { willReadFrequently: true });
+  x.clearRect(0, 0, w, h);
+  x.drawImage(bmpOrImg, 0, 0, w, h);
+
+  const imgData = x.getImageData(0, 0, w, h);
+  const d = imgData.data;
+
+  // Gentle white→alpha like your backend's colorToAlphaWhite()
+  const ramp = Math.max(1, hard - soft); // softness of the transition
+  for (let i = 0; i < d.length; i += 4) {
+    const R = d[i], G = d[i + 1], B = d[i + 2];
+    const A = d[i + 3];
+
+    const wmax = Math.max(R, G, B);
+    let alpha = A;
+
+    if (wmax >= soft) {
+      const cut = Math.max(0, Math.min(1, (wmax - soft) / ramp)); // 0..1
+      alpha = Math.round(A * (1 - cut));
+      if (wmax >= hard) alpha = 0;
+    }
+
+    // Decontaminate fringing: un-premultiply white from RGB where 0<alpha<255
+    if (alpha > 0 && alpha < 255) {
+      const a = alpha / 255;
+      d[i]     = Math.max(0, Math.min(255, Math.round((R - (1 - a) * 255) / a)));
+      d[i + 1] = Math.max(0, Math.min(255, Math.round((G - (1 - a) * 255) / a)));
+      d[i + 2] = Math.max(0, Math.min(255, Math.round((B - (1 - a) * 255) / a)));
+    }
+
+    d[i + 3] = alpha;
+  }
+
+  x.putImageData(imgData, 0, 0);
+
+  // 4) Return a safe, same-origin blob URL (PNG keeps transparency)
+  const blob = await new Promise(res => c.toBlob(res, 'image/png'));
+  return URL.createObjectURL(blob);
+}
+
+async function resizeImage(dataURL, originalMimeType, maxWidth, maxHeight, quality = 0.9) {
+    // Turn dataURL into a Blob
+    const blob = await (await fetch(dataURL)).blob();
+
+    // Prefer createImageBitmap (applies EXIF orientation with the option below)
+    let sourceW, sourceH, draw;
+    if ('createImageBitmap' in window) {
+      const bitmap = await createImageBitmap(blob, { imageOrientation: 'from-image' });
+      sourceW = bitmap.width;
+      sourceH = bitmap.height;
+      draw = (ctx, w, h) => ctx.drawImage(bitmap, 0, 0, w, h);
+    } else {
+      // Fallback path
+      const img = await new Promise((resolve) => {
+        const im = new Image();
+        im.onload = () => resolve(im);
+        im.src = URL.createObjectURL(blob);
+      });
+      sourceW = img.width;
+      sourceH = img.height;
+      draw = (ctx, w, h) => ctx.drawImage(img, 0, 0, w, h);
+    }
+
+    // Contain-fit into the target box (no cropping)
+    const srcAR = sourceW / sourceH;
+    const boxAR = maxWidth / maxHeight;
+    let targetW, targetH;
+    if (srcAR > boxAR) {
+      targetW = maxWidth;
+      targetH = Math.round(maxWidth / srcAR);
+    } else {
+      targetH = maxHeight;
+      targetW = Math.round(maxHeight * srcAR);
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = targetW;
+    canvas.height = targetH;
+    const ctx = canvas.getContext('2d', { alpha: true });
+
+    ctx.clearRect(0, 0, targetW, targetH);
+    draw(ctx, targetW, targetH);
+
+    const outputMimeType = 'image/png';
+    const outputQuality = undefined; // Quality is only for JPEG
+
+    return canvas.toDataURL(outputMimeType, outputQuality);
+}


### PR DESCRIPTION
This commit refactors the image processing logic and applies it to the admin dashboard to ensure tattoo images are shown with transparent backgrounds.

- A new shared script, `frontend/js/image-utils.js`, has been created to house common image manipulation functions.
- The `cleanStencilWhiteBg` and `resizeImage` functions have been moved from `index.html` to the new `image-utils.js` file to promote code reuse.
- `index.html` and `admin.html` now both load `image-utils.js`.
- The event listener for the tattoo upload button in `admin.js` has been updated to be `async` and now calls `cleanStencilWhiteBg` to process the tattoo image before it is passed to the drawing canvas.

This ensures that the tattoo image on the admin page's 'Hill Climbing' tool has its background removed, matching the behavior of the main user application.