### PR TITLE
feat: Add admin dashboard for HillFlux CSV runner

### DIFF
--- a/backend.log
+++ b/backend.log
@@ -1,0 +1,13 @@
+/app/node_modules/@supabase/supabase-js/dist/main/SupabaseClient.js:44
+            throw new Error('supabaseUrl is required.');
+                  ^
+
+Error: supabaseUrl is required.
+    at new SupabaseClient (/app/node_modules/@supabase/supabase-js/dist/main/SupabaseClient.js:44:19)
+    at createClient (/app/node_modules/@supabase/supabase-js/dist/main/index.js:38:12)
+    at file:///app/backend/modules/tokenService.js:11:18
+    at ModuleJob.run (node:internal/modules/esm/module_job:329:25)
+    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+
+Node.js v22.17.1

--- a/backend/modules/hillClimbHandler.js
+++ b/backend/modules/hillClimbHandler.js
@@ -1,0 +1,196 @@
+import Papa from 'papaparse';
+import fetch from 'node-fetch';
+import { createClient } from '@supabase/supabase-js';
+import { v4 as uuidv4 } from 'uuid';
+
+// --- Supabase Setup ---
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+const SUPABASE_STORAGE_BUCKET = process.env.SUPABASE_STORAGE_BUCKET || 'generated-tattoos';
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+const REQUIRED_HEADERS = [
+    'image_id', 'engine', 'adaptive_scale_enabled', 'adaptive_engine_enabled', 'global_scale_up',
+    'kontext_size_bias', 'fill_size_bias', 'model_mask_grow_pct', 'model_mask_grow_min', 'model_mask_grow_max',
+    'bake_tattoo_brightness', 'bake_tattoo_gamma', 'bake_overlay_opacity', 'bake_softlight_opacity',
+    'bake_multiply_opacity', 'prompt_weight', 'negative_prompt_weight', 'pick_of_the_litter',
+    'iteration_feedback', 'engine_call_mode', 'engine_endpoint_url', 'engine_switch_reason'
+];
+
+async function uploadImageToSupabase(imageBuffer, userId, folder, fileName) {
+    const filePath = `${userId}/${folder}/${fileName}`;
+    const { error } = await supabase.storage
+        .from(SUPABASE_STORAGE_BUCKET)
+        .upload(filePath, imageBuffer, {
+            contentType: 'image/png', // Assuming PNG, adjust if needed
+            upsert: false,
+        });
+
+    if (error) {
+        console.error('Supabase upload error:', error);
+        throw new Error(`Failed to upload image to storage: ${error.message}`);
+    }
+
+    const { data: pub } = supabase.storage.from(SUPABASE_STORAGE_BUCKET).getPublicUrl(filePath);
+    if (!pub?.publicUrl) {
+        throw new Error('Failed to get public URL for uploaded image.');
+    }
+    console.log(`Image uploaded to Supabase: ${pub.publicUrl}`);
+    return pub.publicUrl;
+}
+
+async function callFluxApi(payload, apiKey) {
+    console.log('Calling FLUX API with endpoint:', payload.engine_endpoint_url);
+    // This is where the actual API call would happen.
+    // For now, we return a mock URL.
+    if (!apiKey) {
+        console.log("No FLUX API key provided, returning mock data.");
+        const mockImageUrl = `https://picsum.photos/512/512?random=${Math.floor(Math.random() * 1000)}`;
+        return { output_url: mockImageUrl };
+    }
+
+    // Real API call logic (kept for reference)
+    /*
+    const response = await fetch(payload.engine_endpoint_url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`FLUX API request failed with status ${response.status}: ${errorBody}`);
+    }
+
+    return await response.json();
+    */
+
+    // Returning mock for now to avoid actual API calls during dev
+    const mockImageUrl = `https://picsum.photos/512/512?random=${Math.floor(Math.random() * 1000)}`;
+    return { output_url: mockImageUrl };
+}
+
+async function processHillClimbCsv(csvString, tattooImageBuffer, skinImageBuffer, fluxApiKey, userId) {
+    // 1. Upload images to get URIs first
+    const tattooUri = await uploadImageToSupabase(tattooImageBuffer, userId, 'hillclimb/tattoos', `tattoo_${uuidv4()}.png`);
+    const skinUri = await uploadImageToSupabase(skinImageBuffer, userId, 'hillclimb/skins', `skin_${uuidv4()}.png`);
+
+    return new Promise((resolve, reject) => {
+        Papa.parse(csvString, {
+            header: true,
+            skipEmptyLines: true,
+            async complete(results) {
+                try {
+                    // 2. Validate Headers
+                    const headers = results.meta.fields;
+                    const missingHeaders = REQUIRED_HEADERS.filter(h => !headers.includes(h));
+                    if (missingHeaders.length > 0) {
+                        throw new Error(`Missing required CSV headers: ${missingHeaders.join(', ')}`);
+                    }
+
+                    // 3. Validate Rows
+                    const rows = results.data;
+                    if (rows.length !== 3) {
+                        throw new Error(`CSV must contain exactly 3 data rows, but found ${rows.length}.`);
+                    }
+
+                    const outputUrls = [];
+                    // 4. Process rows sequentially
+                    for (const row of rows) {
+                        const params = {
+                            adaptive_scale_enabled: parseInt(row.adaptive_scale_enabled, 10),
+                            adaptive_engine_enabled: parseInt(row.adaptive_engine_enabled, 10),
+                            global_scale_up: parseFloat(row.global_scale_up),
+                            kontext_size_bias: parseFloat(row.kontext_size_bias),
+                            fill_size_bias: parseFloat(row.fill_size_bias),
+                            model_mask_grow_pct: parseFloat(row.model_mask_grow_pct),
+                            model_mask_grow_min: parseInt(row.model_mask_grow_min, 10),
+                            model_mask_grow_max: parseInt(row.model_mask_grow_max, 10),
+                            bake_tattoo_brightness: parseFloat(row.bake_tattoo_brightness),
+                            bake_tattoo_gamma: parseFloat(row.bake_tattoo_gamma),
+                            bake_overlay_opacity: parseFloat(row.bake_overlay_opacity),
+                            bake_softlight_opacity: parseFloat(row.bake_softlight_opacity),
+                            bake_multiply_opacity: parseFloat(row.bake_multiply_opacity),
+                            prompt_weight: parseFloat(row.prompt_weight),
+                            negative_prompt_weight: parseFloat(row.negative_prompt_weight),
+                        };
+
+                        for (const key in params) {
+                            if (isNaN(params[key])) {
+                                throw new Error(`Invalid numeric value for '${key}' in row with image_id '${row.image_id}'.`);
+                            }
+                        }
+
+                        const payload = {
+                            engine: row.engine,
+                            params: params,
+                            tattoo_uri: tattooUri,
+                            skin_uri: skinUri,
+                            mask_uri: "", // Mask is not part of this flow yet
+                            prompt: "Preserve the exact silhouette, proportions and interior details of the tattoo. Blend it realistically into the skin with lighting, micro-shadowing and subtle ink diffusion. Do not redraw, restyle or resize. Keep the original tonal balance and colors; avoid pure white ink effects or global darkening.",
+                            mode: row.engine_call_mode,
+                            engine_endpoint_url: row.engine_endpoint_url, // Pass endpoint for the API call
+                        };
+
+                        const response = await callFluxApi(payload, fluxApiKey);
+                        outputUrls.push({
+                            image_id: row.image_id,
+                            url: response.output_url,
+                            params: params,
+                        });
+                    }
+
+                    resolve({
+                        images: outputUrls,
+                        engine_switch_reason: rows[0].engine_switch_reason,
+                        engine_call_mode: rows[0].engine_call_mode,
+                    });
+
+                } catch (error) {
+                    reject(error);
+                }
+            },
+            error(err) {
+                reject(err);
+            }
+        });
+    });
+}
+
+function updateCsvWithFeedback(csvString, pickOfTheLitter, iterationFeedback) {
+    return new Promise((resolve, reject) => {
+        Papa.parse(csvString, {
+            header: true,
+            skipEmptyLines: true,
+            complete(results) {
+                try {
+                    const rows = results.data;
+                    // Update all rows with the same feedback and pick
+                    const updatedRows = rows.map(row => ({
+                        ...row,
+                        pick_of_the_litter: pickOfTheLitter,
+                        iteration_feedback: iterationFeedback,
+                    }));
+
+                    // Convert back to CSV string, including headers
+                    const updatedCsvString = Papa.unparse(updatedRows, {
+                        header: true,
+                    });
+
+                    resolve(updatedCsvString);
+
+                } catch (error) {
+                    reject(new Error(`Failed to update CSV: ${error.message}`));
+                }
+            },
+            error(err) {
+                reject(new Error(`Failed to parse CSV for updating: ${err.message}`));
+            }
+        });
+    });
+}
+
+export default { processHillClimbCsv, updateCsvWithFeedback };

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ import sizeOf from 'image-size'; // image-size default export might be different
 // Import our new modularized services
 import tokenService from './modules/tokenService.js'; // Added .js extension
 import fluxKontextHandler from './modules/fluxPlacementHandler.js'; // Added .js extension
+import hillClimbHandler from './modules/hillClimbHandler.js'; // Added for admin panel
 // --- END OF ACTUAL IMPORTS ---
 
 // Function to generate a dynamic timestamp for deployment tracking
@@ -362,6 +363,72 @@ app.post('/api/admin/debug-add-tokens', authenticateToken, async (req, res) => {
         res.status(500).json({ error: `Failed to add tokens via debug endpoint: ${error.message}` });
     }
 });
+
+app.post('/api/admin/hill-climb',
+    authenticateToken, // Assuming admin routes should be protected
+    upload.fields([
+        { name: 'tattooImage', maxCount: 1 },
+        { name: 'skinImage', maxCount: 1 }
+    ]),
+    async (req, res) => {
+        try {
+            console.log('API: /api/admin/hill-climb endpoint called.');
+            const userId = req.user.id;
+            const { csvData } = req.body;
+            const tattooImageFile = req.files.tattooImage ? req.files.tattooImage[0] : null;
+            const skinImageFile = req.files.skinImage ? req.files.skinImage[0] : null;
+
+            if (!csvData || !tattooImageFile || !skinImageFile) {
+                return res.status(400).json({ error: 'Missing csvData, tattooImage, or skinImage.' });
+            }
+
+            // Note: We are not using the fluxKontextHandler.uploadToSupabaseStorage here directly
+            // Instead, we pass the buffers to the hillClimbHandler, which will manage its own uploads.
+            const results = await hillClimbHandler.processHillClimbCsv(
+                csvData,
+                tattooImageFile.buffer,
+                skinImageFile.buffer,
+                process.env.FLUX_API_KEY,
+                userId // Pass userId for storage paths
+            );
+
+            res.json(results);
+
+        } catch (error) {
+            console.error('API Error in /api/admin/hill-climb:', error);
+            res.status(500).json({
+                error: 'An internal server error occurred during the hill climb process.',
+                details: error.message
+            });
+        }
+    }
+);
+
+app.post('/api/admin/update-csv', authenticateToken, async (req, res) => {
+    try {
+        const { csvData, pickOfTheLitter, iterationFeedback } = req.body;
+
+        if (!csvData || !pickOfTheLitter) {
+            return res.status(400).json({ error: 'Missing csvData or pickOfTheLitter selection.' });
+        }
+
+        const updatedCsv = await hillClimbHandler.updateCsvWithFeedback(
+            csvData,
+            pickOfTheLitter,
+            iterationFeedback || '' // Default to empty string if feedback is null/undefined
+        );
+
+        res.json({ updatedCsvString: updatedCsv });
+
+    } catch (error) {
+        console.error('API Error in /api/admin/update-csv:', error);
+        res.status(500).json({
+            error: 'An internal server error occurred while updating the CSV.',
+            details: error.message
+        });
+    }
+});
+
 
 app.post('/api/generate-final-tattoo',
     authenticateToken,

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin - HillFlux Runner</title>
+    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="css/admin.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="container">
+            <div class="nav-brand">
+                <h1>Slate.Tattoo - Admin</h1>
+            </div>
+        </div>
+    </nav>
+
+    <main class="main-content">
+        <div class="container">
+            <section id="hillFluxRunnerSection" class="section">
+                <div class="section-header">
+                    <h2>HillFlux CSV Runner</h2>
+                    <p>Upload a HillFlux CSV to execute the defined FLUX image generation tasks.</p>
+                </div>
+
+                <div class="upload-area" id="csvUploadArea">
+                    <input type="file" id="csvFileInput" accept=".csv" hidden>
+                    <div class="upload-placeholder">
+                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="17 8 12 3 7 8"></polyline>
+                            <line x1="12" y1="3" x2="12" y2="15"></line>
+                        </svg>
+                        <p>Click to upload or drag and drop a CSV file</p>
+                        <span>(e.g., hillflux_round_001.csv)</span>
+                    </div>
+                </div>
+
+                <div class="image-upload-container" style="display: none;">
+                    <h4>Upload Base Images</h4>
+                    <div class="image-inputs">
+                        <div>
+                            <label for="tattooImageInput">Tattoo Stencil:</label>
+                            <input type="file" id="tattooImageInput" accept="image/png,image/jpeg,image/webp">
+                        </div>
+                        <div>
+                            <label for="skinImageInput">Skin Photo:</label>
+                            <input type="file" id="skinImageInput" accept="image/png,image/jpeg,image/webp">
+                        </div>
+                    </div>
+                    <button id="runHillFluxBtn" class="btn btn-primary" disabled>Run HillFlux Round</button>
+                </div>
+            </section>
+
+            <div id="loadingOverlay" class="loading-overlay" style="display: none;">
+                <div class="loading-content">
+                    <div class="spinner"></div>
+                    <p id="loadingText">Executing FLUX tasks...</p>
+                </div>
+            </div>
+
+            <section id="resultsSection" class="section" style="display: none;">
+                <div class="section-header">
+                    <h2 id="resultsHeader">Round Results</h2>
+                </div>
+                <div id="infoBanner" class="info-banner" style="display: none;"></div>
+                <div class="results-grid">
+                    <!-- Results will be dynamically populated here -->
+                </div>
+
+                <div id="feedbackSection" class="feedback-section" style="display: none;">
+                    <h3>Submit Feedback</h3>
+                    <form id="feedbackForm">
+                        <div class="form-group">
+                            <label>Which image is the "Pick of the Litter"?</label>
+                            <div class="radio-group" id="pickOfTheLitter">
+                                <!-- Radio buttons will be populated here -->
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="iterationFeedback">Iteration Feedback:</label>
+                            <textarea id="iterationFeedback" rows="3" placeholder="e.g., Edges blend well but slightly bright..."></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Update & Download CSV</button>
+                    </form>
+                </div>
+            </section>
+
+        </div>
+    </main>
+
+    <script src="https://unpkg.com/papaparse@5.3.2/papaparse.min.js"></script>
+    <script src="js/admin.js"></script>
+</body>
+</html>

--- a/frontend/css/admin.css
+++ b/frontend/css/admin.css
@@ -1,0 +1,110 @@
+/* Admin-specific styles */
+
+.image-upload-container {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+}
+
+.image-upload-container h4 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.image-inputs {
+    display: flex;
+    gap: 2rem;
+    margin-bottom: 1.5rem;
+}
+
+#runHillFluxBtn {
+    display: block;
+    margin-left: auto;
+}
+
+.info-banner {
+    background-color: #e7f3ff;
+    border: 1px solid #b3d7ff;
+    border-radius: 4px;
+    padding: 1rem;
+    margin-bottom: 2rem;
+    font-size: 0.95rem;
+}
+
+.results-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.result-item {
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    overflow: hidden;
+    background-color: #fff;
+}
+
+.result-item img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.result-item .params {
+    padding: 1rem;
+    font-size: 0.85rem;
+    background-color: #fafafa;
+}
+
+.result-item .params h4 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+.result-item .params pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    background: #eee;
+    padding: 0.5rem;
+    border-radius: 4px;
+}
+
+.result-item .copy-btn {
+    display: block;
+    width: calc(100% - 2rem);
+    margin: 1rem;
+}
+
+.feedback-section {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid #e0e0e0;
+}
+
+.radio-group {
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.form-group textarea {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 1rem;
+}

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -1,0 +1,284 @@
+document.addEventListener('DOMContentLoaded', () => {
+    console.log('Admin JS loaded.');
+
+    // --- STATE ---
+    let csvFileContent = null;
+    let tattooImageFile = null;
+    let skinImageFile = null;
+    let lastCsvFileName = '';
+
+    // --- DOM ELEMENTS ---
+    const csvUploadArea = document.getElementById('csvUploadArea');
+    const csvFileInput = document.getElementById('csvFileInput');
+    const imageUploadContainer = document.querySelector('.image-upload-container');
+    const tattooImageInput = document.getElementById('tattooImageInput');
+    const skinImageInput = document.getElementById('skinImageInput');
+    const runHillFluxBtn = document.getElementById('runHillFluxBtn');
+    const loadingOverlay = document.getElementById('loadingOverlay');
+    const loadingText = document.getElementById('loadingText');
+    const resultsSection = document.getElementById('resultsSection');
+    const resultsHeader = document.getElementById('resultsHeader');
+    const infoBanner = document.getElementById('infoBanner');
+    const resultsGrid = document.querySelector('.results-grid');
+    const feedbackSection = document.getElementById('feedbackSection');
+
+    // --- UTILS ---
+    const showLoading = (text) => {
+        loadingText.textContent = text || 'Processing...';
+        loadingOverlay.style.display = 'flex';
+    };
+
+    const hideLoading = () => {
+        loadingOverlay.style.display = 'none';
+    };
+
+    const showAlert = (message, type = 'error') => {
+        // Simple alert for now, can be replaced with a nicer modal
+        alert(`[${type.toUpperCase()}] ${message}`);
+    };
+
+    const updateRunButtonState = () => {
+        if (csvFileContent && tattooImageFile && skinImageFile) {
+            runHillFluxBtn.disabled = false;
+        } else {
+            runHillFluxBtn.disabled = true;
+        }
+    };
+
+    // --- EVENT LISTENERS ---
+    csvUploadArea.addEventListener('click', () => csvFileInput.click());
+
+    csvFileInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            lastCsvFileName = file.name;
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                csvFileContent = e.target.result;
+                csvUploadArea.querySelector('p').textContent = `CSV Loaded: ${file.name}`;
+                imageUploadContainer.style.display = 'block';
+                updateRunButtonState();
+            };
+            reader.onerror = () => {
+                showAlert('Failed to read the CSV file.');
+                csvFileContent = null;
+                updateRunButtonState();
+            };
+            reader.readAsText(file);
+        }
+    });
+
+    tattooImageInput.addEventListener('change', (event) => {
+        tattooImageFile = event.target.files[0];
+        updateRunButtonState();
+    });
+
+    skinImageInput.addEventListener('change', (event) => {
+        skinImageFile = event.target.files[0];
+        updateRunButtonState();
+    });
+
+    runHillFluxBtn.addEventListener('click', async () => {
+        if (!csvFileContent || !tattooImageFile || !skinImageFile) {
+            showAlert('Please provide a CSV file, a tattoo image, and a skin image.');
+            return;
+        }
+
+        // A placeholder for getting the auth token.
+        // In a real app, you'd get this from localStorage or a state management solution.
+        const token = localStorage.getItem('token');
+        if (!token) {
+            showAlert('Authentication token not found. Please log in.');
+            // Potentially redirect to login page
+            return;
+        }
+
+        showLoading('Uploading images and processing CSV...');
+
+        const formData = new FormData();
+        formData.append('csvData', csvFileContent);
+        formData.append('tattooImage', tattooImageFile);
+        formData.append('skinImage', skinImageFile);
+
+        try {
+            const response = await fetch('/api/admin/hill-climb', {
+                method: 'POST',
+                headers: {
+                    // 'Content-Type' is automatically set by the browser when using FormData
+                    'Authorization': `Bearer ${token}`
+                },
+                body: formData,
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.details || errorData.error || 'The server returned an error.');
+            }
+
+            const results = await response.json();
+            displayResults(results);
+
+        } catch (error) {
+            console.error('HillFlux run failed:', error);
+            showAlert(`An error occurred: ${error.message}`);
+        } finally {
+            hideLoading();
+        }
+    });
+
+
+    // --- UI RENDERING ---
+    function displayResults(data) {
+        // Extract round number from the original filename
+        const roundMatch = lastCsvFileName.match(/round_(\d+)/i);
+        const roundNumber = roundMatch ? parseInt(roundMatch[1], 10) : 'N/A';
+        resultsHeader.textContent = `Round ${roundNumber} Results`;
+
+        // Show info banner
+        infoBanner.textContent = `Engine Call Mode: ${data.engine_call_mode} | Reason: ${data.engine_switch_reason}`;
+        infoBanner.style.display = 'block';
+
+        // Clear previous results
+        resultsGrid.innerHTML = '';
+        const pickOfTheLitterContainer = document.getElementById('pickOfTheLitter');
+        pickOfTheLitterContainer.innerHTML = '';
+
+
+        // Populate results grid and feedback radio buttons
+        data.images.forEach((imageResult, index) => {
+            const paramsHtml = `<pre>${JSON.stringify(imageResult.params, null, 2)}</pre>`;
+            const resultItem = document.createElement('div');
+            resultItem.className = 'result-item';
+            resultItem.innerHTML = `
+                <img src="${imageResult.url}" alt="Generated image for ${imageResult.image_id}">
+                <div class="params">
+                    <h4>${imageResult.image_id}</h4>
+                    ${paramsHtml}
+                    <button class="btn btn-secondary btn-sm copy-btn" data-params='${JSON.stringify(imageResult.params)}'>Copy Params</button>
+                </div>
+            `;
+            resultsGrid.appendChild(resultItem);
+
+            // Populate radio buttons
+            const radioLabel = document.createElement('label');
+            const radioButton = document.createElement('input');
+            radioButton.type = 'radio';
+            radioButton.name = 'pickOfTheLitter';
+            radioButton.value = imageResult.image_id;
+            if (index === 0) {
+                radioButton.checked = true; // Default check the first one
+            }
+            radioLabel.appendChild(radioButton);
+            radioLabel.append(` ${imageResult.image_id}`);
+            pickOfTheLitterContainer.appendChild(radioLabel);
+        });
+
+        // Show the results and feedback sections
+        resultsSection.style.display = 'block';
+        feedbackSection.style.display = 'block';
+
+        // Scroll to results
+        resultsSection.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    // --- FEEDBACK FORM HANDLING ---
+    const feedbackForm = document.getElementById('feedbackForm');
+    feedbackForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        showLoading('Updating CSV...');
+
+        const formData = new FormData(event.target);
+        const pickOfTheLitter = formData.get('pickOfTheLitter');
+        const iterationFeedback = document.getElementById('iterationFeedback').value;
+
+        const token = localStorage.getItem('token');
+        if (!token) {
+            showAlert('Authentication token not found. Please log in.');
+            hideLoading();
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/admin/update-csv', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+                body: JSON.stringify({
+                    csvData: csvFileContent,
+                    pickOfTheLitter,
+                    iterationFeedback
+                })
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.details || 'Failed to update CSV.');
+            }
+
+            const { updatedCsvString } = await response.json();
+
+            // Trigger download
+            const roundMatch = lastCsvFileName.match(/round_(\d+)/i);
+            const roundNumber = roundMatch ? roundMatch[1] : 'unknown';
+            const updatedFileName = `hillflux_round_${roundNumber}_updated.csv`;
+
+            const blob = new Blob([updatedCsvString], { type: 'text/csv;charset=utf-8;' });
+            const link = document.createElement('a');
+            const url = URL.createObjectURL(blob);
+            link.setAttribute('href', url);
+            link.setAttribute('download', updatedFileName);
+            link.style.visibility = 'hidden';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+
+        } catch (error) {
+            showAlert(`Failed to update and download CSV: ${error.message}`);
+        } finally {
+            hideLoading();
+        }
+    });
+
+    // --- COPY PARAMS BUTTON HANDLING ---
+    resultsGrid.addEventListener('click', (event) => {
+        if (event.target.classList.contains('copy-btn')) {
+            const button = event.target;
+            const paramsString = button.dataset.params;
+
+            if (!navigator.clipboard) {
+                showAlert('Clipboard API not available in this browser.', 'warning');
+                return;
+            }
+
+            if (!paramsString) {
+                showAlert('No parameters found to copy.', 'error');
+                return;
+            }
+
+            // The data-params attribute is already a JSON string.
+            // For a slightly nicer format, we can parse and re-stringify it.
+            try {
+                const paramsObject = JSON.parse(paramsString);
+                const formattedParams = JSON.stringify(paramsObject, null, 2);
+
+                navigator.clipboard.writeText(formattedParams).then(() => {
+                    const originalText = button.textContent;
+                    button.textContent = 'Copied!';
+                    button.disabled = true;
+                    setTimeout(() => {
+                        button.textContent = originalText;
+                        button.disabled = false;
+                    }, 2000);
+                }).catch(err => {
+                    console.error('Failed to copy params:', err);
+                    showAlert('Failed to copy parameters to clipboard.');
+                });
+            } catch (e) {
+                console.error('Failed to parse params from data attribute:', e);
+                showAlert('Could not copy malformed parameter data.');
+            }
+        }
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "image-size": "^1.1.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
+        "node-fetch": "^3.3.2",
+        "papaparse": "^5.5.3",
         "sharp": "^0.33.4",
         "uuid": "^9.0.1"
       },
@@ -842,6 +844,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1059,6 +1070,29 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1124,6 +1158,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -1639,6 +1685,44 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -1735,6 +1819,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -2275,6 +2365,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "image-size": "^1.1.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
+    "node-fetch": "^3.3.2",
+    "papaparse": "^5.5.3",
     "sharp": "^0.33.4",
     "uuid": "^9.0.1"
   },


### PR DESCRIPTION
This commit introduces a new admin dashboard for running HillFlux experiments.

The dashboard allows an admin to upload a CSV file with specific FLUX parameters, along with a base tattoo and skin image.

The backend processes the CSV sequentially, calls the (mocked) FLUX API for each row, and returns the generated images. The frontend displays the results, allows the admin to select the best image ("pick of the litter"), and provide feedback.

The updated information can then be downloaded as a new CSV file. A "Copy Parameters" button is also included for convenience.

Key changes:
- Adds admin.html, admin.css, and admin.js to the frontend.
- Creates a new backend/modules/hillClimbHandler.js for the core logic.
- Adds /api/admin/hill-climb and /api/admin/update-csv endpoints to server.js.
- Installs papaparse and node-fetch dependencies.