### PR TITLE
fix: Add placeholder admin API endpoints

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -429,6 +429,39 @@ app.post('/api/admin/update-csv', authenticateToken, async (req, res) => {
     }
 });
 
+// --- Placeholder endpoints for new admin functionality ---
+app.get('/api/admin/flux-settings', authenticateToken, async (req, res) => {
+    console.log('Placeholder endpoint hit: /api/admin/flux-settings');
+    // Returning a default object structure to avoid frontend errors
+    res.json({
+        // Default values, to be replaced with actual data from Supabase
+        adaptive_scale_enabled: true,
+        adaptive_engine_enabled: true,
+        global_scale_up: 1.5,
+        kontext_size_bias: 1.08,
+        fill_size_bias: 1.02,
+        model_mask_grow_pct: 0.06,
+        model_mask_grow_min: 4,
+        model_mask_grow_max: 28,
+        bake_tattoo_brightness: 1.0,
+        bake_tattoo_gamma: 1.0,
+        bake_overlay_opacity: 0.28,
+        bake_softlight_opacity: 0.22,
+        bake_multiply_opacity: 0.06,
+    });
+});
+
+app.get('/api/admin/flux-settings/history', authenticateToken, async (req, res) => {
+    console.log('Placeholder endpoint hit: /api/admin/flux-settings/history');
+    res.json([]); // Return an empty array as it's likely a list
+});
+
+app.get('/api/admin/presets', authenticateToken, async (req, res) => {
+    console.log('Placeholder endpoint hit: /api/admin/presets');
+    res.json([]); // Return an empty array as it's likely a list
+});
+// --- End of placeholder endpoints ---
+
 
 app.post('/api/generate-final-tattoo',
     authenticateToken,


### PR DESCRIPTION
This commit adds placeholder endpoints for:
- GET /api/admin/flux-settings
- GET /api/admin/flux-settings/history
- GET /api/admin/presets

These endpoints were returning 404 errors in the deployed environment, preventing the admin page from loading correctly.

This is a temporary measure to resolve the 404 errors and allow for further investigation into the frontend's data requirements. The endpoints currently return default or empty data and will be fully implemented in a subsequent commit.