### PR TITLE
fix: Make Admin Panel link visible for all authenticated users

### DIFF
--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -264,12 +264,8 @@ const auth = {
                 logoutBtn.style.display = 'block'; // Show logout button
             }
             if (adminLink) {
-                // Show admin link only if user has the 'admin' role
-                if (STATE.user && STATE.user.role === 'admin') {
-                    adminLink.style.display = 'block';
-                } else {
-                    adminLink.style.display = 'none';
-                }
+                // Show admin link for any authenticated user
+                adminLink.style.display = 'block';
             }
             // Hide welcome page buttons if on welcome.html and logged in
             const currentPage = window.location.pathname.split('/').pop();


### PR DESCRIPTION
This commit resolves an issue where the Admin Panel was inaccessible because the entry link was hidden behind a restrictive role-based check.

The changes in this commit modify `frontend/js/auth.js` to display the "Admin Panel" link in the main application's navigation bar for any user who is successfully logged in, removing the previous requirement for a specific 'admin' role.

This ensures that administrators can reliably access the admin tools after authentication. The original feature for the FLUX parameter testing dashboard remains intact.