### PR TITLE
fix: Correct navigation links to use relative paths

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -14,8 +14,8 @@
                 <h1>Slate.Tattoo - Admin</h1>
             </div>
             <div class="nav-menu">
-                <a href="/admin.html" class="btn btn-outline active">HillFlux Runner</a>
-                <a href="/admin_flux.html" class="btn btn-outline">FLUX Tester</a>
+                <a href="admin.html" class="btn btn-outline active">HillFlux Runner</a>
+                <a href="admin_flux.html" class="btn btn-outline">FLUX Tester</a>
             </div>
         </div>
     </nav>

--- a/frontend/admin_flux.html
+++ b/frontend/admin_flux.html
@@ -14,8 +14,8 @@
                 <h1>Slate.Tattoo - Admin</h1>
             </div>
             <div class="nav-menu">
-                <a href="/admin.html" class="btn btn-outline">HillFlux Runner</a>
-                <a href="/admin_flux.html" class="btn btn-outline active">FLUX Tester</a>
+                <a href="admin.html" class="btn btn-outline">HillFlux Runner</a>
+                <a href="admin_flux.html" class="btn btn-outline active">FLUX Tester</a>
             </div>
         </div>
     </nav>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,7 +36,7 @@
                 <span class="tagline">AI Tattoo Platform</span> </div>
             <div class="nav-menu">
                 <span id="userInfo" class="user-info"></span>
-                <a href="/admin.html" id="adminLink" class="btn btn-outline" style="display:none;">Admin Panel</a>
+                <a href="admin.html" id="adminLink" class="btn btn-outline" style="display:none;">Admin Panel</a>
                 <button id="logoutBtn" class="btn btn-outline" style="display:none;">Logout</button>
             </div>
         </div>


### PR DESCRIPTION
This commit resolves a '404 Not Found' error that occurred on GitHub Pages because the navigation links were using absolute paths (e.g., `/admin.html`). Absolute paths do not work correctly in a subdirectory-based deployment like GitHub Pages.

The following files have been updated to use relative paths (e.g., `admin.html`), ensuring that all links function correctly in any hosting environment:
- `frontend/index.html`
- `frontend/admin.html`
- `frontend/admin_flux.html`

This change ensures that users can navigate between the main application and the admin pages without encountering 404 errors.